### PR TITLE
Added support for Android notification color

### DIFF
--- a/scr/Plugin.LocalNotification/AndroidOptions.cs
+++ b/scr/Plugin.LocalNotification/AndroidOptions.cs
@@ -13,6 +13,11 @@ namespace Plugin.LocalNotification
         public bool AutoCancel { get; set; } = true;
 
         /// <summary>
+        /// If set, the notification icon and application name will have the provided ARGB color.
+        /// </summary>
+        public int? Color { get; set; }
+
+        /// <summary>
         /// Set the relative priority for this notification.
         /// </summary>
         public NotificationPriority Priority { get; set; } = NotificationPriority.Default;

--- a/scr/Plugin.LocalNotification/AndroidOptions.cs
+++ b/scr/Plugin.LocalNotification/AndroidOptions.cs
@@ -18,6 +18,11 @@ namespace Plugin.LocalNotification
         public int? Color { get; set; }
 
         /// <summary>
+        /// If set, the LED will have the provided ARGB color.
+        /// </summary>
+        public int? LedColor { get; set; }
+
+        /// <summary>
         /// Set the relative priority for this notification.
         /// </summary>
         public NotificationPriority Priority { get; set; } = NotificationPriority.Default;

--- a/scr/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/scr/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -170,6 +170,12 @@ namespace Plugin.LocalNotification.Platform.Droid
                 builder.SetNumber(notificationRequest.BadgeNumber);
                 builder.SetAutoCancel(notificationRequest.Android.AutoCancel);
                 builder.SetPriority((int)notificationRequest.Android.Priority);
+
+                if( notificationRequest.Android.Color.HasValue)
+                {
+                    builder.SetColor(notificationRequest.Android.Color.Value);
+                }
+
                 if (notificationRequest.Android.TimeoutAfter.HasValue)
                 {
                     builder.SetTimeoutAfter((long)notificationRequest.Android.TimeoutAfter.Value.TotalMilliseconds);

--- a/scr/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/scr/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -233,6 +233,12 @@ namespace Plugin.LocalNotification.Platform.Droid
                 }
 
                 var notification = builder.Build();
+
+                if( notificationRequest.Android.LedColor.HasValue )
+                {
+                    notification.LedARGB = notificationRequest.Android.LedColor.Value;
+                }
+
                 notification.Defaults = NotificationDefaults.All;
 
                 _notificationManager.Notify(notificationRequest.NotificationId, notification);


### PR DESCRIPTION
### What does this PR do?
It adds support for icon/app name colors on Android. https://i.imgur.com/MteCi2e.png

##### Why are we doing this? Any context or related work?
Most applications behave this way on android. It also allows you to further distinct your application from others.
