### PR TITLE
Ask for iOS permissions just while, and if needed

### DIFF
--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -20,26 +20,6 @@ namespace Plugin.LocalNotification
             try
             {
                 Current = new Platform.iOS.NotificationServiceImpl();
-
-                if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0) == false)
-                {
-                    return;
-                }
-
-                var alertsAllowed = false;
-
-                UNUserNotificationCenter.Current.GetNotificationSettings((settings) =>
-                {
-                    alertsAllowed = settings.AlertSetting == UNNotificationSetting.Enabled;
-                });
-
-                if (!alertsAllowed)
-                {
-                    // Ask the user for permission to get notifications on iOS 10.0+
-                    UNUserNotificationCenter.Current.RequestAuthorizationAsync(
-                        UNAuthorizationOptions.Alert | UNAuthorizationOptions.Badge | UNAuthorizationOptions.Sound);
-                }
-
                 UNUserNotificationCenter.Current.Delegate = new LocalNotificationDelegate();
             }
             catch (Exception ex)

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -73,6 +73,8 @@ namespace Plugin.LocalNotification.Platform.iOS
                     return;
                 }
 
+                AskPermission();
+
                 if (notificationRequest is null)
                 {
                     return;
@@ -138,6 +140,23 @@ namespace Plugin.LocalNotification.Platform.iOS
                 Minute = dateTime.Minute,
                 Second = dateTime.Second
             };
+        }
+
+        private void AskPermission()
+        {
+            var alertsAllowed = false;
+
+            UNUserNotificationCenter.Current.GetNotificationSettings((settings) =>
+            {
+                alertsAllowed = settings.AlertSetting == UNNotificationSetting.Enabled;
+            });
+
+            if (!alertsAllowed)
+            {
+                // Ask the user for permission to get notifications on iOS 10.0+
+                UNUserNotificationCenter.Current.RequestAuthorizationAsync(
+                    UNAuthorizationOptions.Alert | UNAuthorizationOptions.Badge | UNAuthorizationOptions.Sound);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR will ask only permission if a notification is pushed to the App.
In the original situation the user is asked for the permission on start-up, but imo you will give the user the explain the user why they need to give permission in more detail than the OS does.
So, if the notification is shown or set, it will check if the permission is set. If not, then it will ask only.
