### PR TITLE
Dependabot/nuget/source/xamarin.android x.work.runtime 2.3.3

### DIFF
--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <PackageReference Include="Xamarin.AndroidX.Work.Runtime" Version="2.3.3" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.2.0" />
     <Compile Include="**/Platform/Droid/**/*.cs" />
   </ItemGroup>
 

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Work.Runtime" Version="2.2.0" />
+    <PackageReference Include="Xamarin.AndroidX.Work.Runtime" Version="2.3.3" />
     <Compile Include="**/Platform/Droid/**/*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
### What does this PR do?
- Upgrade the package Xamarin.AndroidX.Work.Runtime from 2.2.0 to 2.3.3.
- Add the missing package Xamarin.AndroidX.Core version 1.2.0.

##### Why are we doing this? Any context or related work?
The upgrade of Xamarin.AndroidX.Work.Runtime from 2.2.0 to 2.3.3 removed AndroidX.Core.App.NotificationCompat. AndroidX.Core.App.NotificationCompat is now located in the package Xamarin.AndroidX.Core version 1.2.0.