### PR TITLE
Notification received event

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ public partial class App : Application
 }
 ```
 
+### Notification received event
+*On iOS this event is fired only when the app is in foreground*
+
+```csharp
+public partial class App : Application
+{
+	public App()
+	{
+		InitializeComponent();
+
+		// Local Notification received event listener
+		NotificationCenter.Current.NotificationReceived += OnLocalNotificationReceived;
+
+		MainPage = new MainPage();
+	}
+	
+	private void OnLocalNotificationReceived(NotificationReceivedEventArgs e)
+    	{
+		// your code goes here
+	}
+}
+```
+
 # Platform Specific Notes
 
 ### Android

--- a/Sample/Direct/LocalNotification.Sample.Android/LocalNotification.Sample.Android.csproj
+++ b/Sample/Direct/LocalNotification.Sample.Android/LocalNotification.Sample.Android.csproj
@@ -42,7 +42,7 @@
     <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
-    <AndroidUseAapt2>false</AndroidUseAapt2>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
     <MandroidI18n />
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml
@@ -19,16 +19,23 @@
             <Switch x:Name="RepeatSwitch" IsToggled="false" />
         </StackLayout>
         <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
+            <Label Text="Display Alert on notification received " />
+            <Switch x:Name="CustomAlert" IsToggled="false" />
+        </StackLayout>
+
+        <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
             <Label Text="Use Custom Sound" />
             <Switch x:Name="CustomSoundSwitch" IsToggled="false" />
         </StackLayout>
         <Label HorizontalOptions="Center" Text="In Android &gt;= 26, Use NotificationChannel to set Sound" />
 
         <!--  Place new controls here  -->
+        <StackLayout VerticalOptions="CenterAndExpand">
         <Button
             Clicked="Button_Clicked"
             HorizontalOptions="Center"
             Text="Send Local Notification"
-            VerticalOptions="CenterAndExpand" />
+            VerticalOptions="Center" />
+        </StackLayout>
     </StackLayout>
 </ContentPage>

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
@@ -110,7 +110,7 @@ namespace LocalNotification.Sample
                 },
                 iOS =
                 {
-                    HideAlertOnNotificationReceived = CustomAlert.IsToggled
+                    HideForegroundAlert = CustomAlert.IsToggled
                 }
             };
 

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
@@ -12,12 +12,26 @@ namespace LocalNotification.Sample
         public MainPage()
         {
             InitializeComponent();
+
+            NotificationCenter.Current.NotificationReceived += ShowCustomAlertFromNotification;
+
             NotifyDatePicker.MinimumDate = DateTime.Today;
             NotifyTimePicker.Time = DateTime.Now.TimeOfDay.Add(TimeSpan.FromSeconds(10));
 
             ScheduleNotificationGroup();
             ScheduleNotification("first", 5);
             ScheduleNotification("second", 10);
+        }
+
+        private void ShowCustomAlertFromNotification(NotificationReceivedEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine(e);
+
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                if (CustomAlert.IsToggled)
+                    DisplayAlert(e.Title, e.Description, "OK");
+            });
         }
 
         private void ScheduleNotificationGroup()
@@ -94,6 +108,10 @@ namespace LocalNotification.Sample
                     //AutoCancel = false,
                     //Ongoing = true
                 },
+                iOS =
+                {
+                    HideAlertOnNotificationReceived = CustomAlert.IsToggled
+                }
             };
 
             // if not specified, default sound will be played.
@@ -117,5 +135,6 @@ namespace LocalNotification.Sample
 
             NotificationCenter.Current.Show(request);
         }
+
     }
 }

--- a/Source/Plugin.LocalNotification/INotificationService.cs
+++ b/Source/Plugin.LocalNotification/INotificationService.cs
@@ -11,6 +11,12 @@
         event NotificationTappedEventHandler NotificationTapped;
 
         /// <summary>
+        /// fires when notification is received.
+        /// On iOS this event is fired only when the app is in foreground
+        /// </summary>
+        event NotificationReceivedEventHandler NotificationReceived;
+
+        /// <summary>
         /// Cancel a notification match with the Id
         /// </summary>
         /// <param name="notificationId">A unique identifier for the already displaying local notification.</param>
@@ -26,6 +32,12 @@
         /// </summary>
         /// <param name="e"></param>
         void OnNotificationTapped(NotificationTappedEventArgs e);
+
+        /// <summary>
+        /// Internal use Only
+        /// </summary>
+        /// <param name="e"></param>
+        void OnNotificationReceived(NotificationReceivedEventArgs e);
 
         /// <summary>
         /// Send a local notification to the device.

--- a/Source/Plugin.LocalNotification/NotificationReceivedEventArgs.cs
+++ b/Source/Plugin.LocalNotification/NotificationReceivedEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Plugin.LocalNotification
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="e"></param>
+
+    public delegate void NotificationReceivedEventHandler(NotificationReceivedEventArgs e);
+
+    /// <summary>
+    /// Returning event when a notification is received.
+    /// On iOS this event is fired only when the app is in foreground
+    /// </summary>
+    public class NotificationReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Returning title when a notification is received.
+        /// </summary>
+        public string Title { get; internal set; }
+
+        /// <summary>
+        /// Returning details when a notification is received.
+        /// </summary>
+        public string Description { get; internal set; } = string.Empty;
+
+        /// <summary>
+        /// Returning data when a notification is received.
+        /// </summary>
+        public string Data { get; internal set; }
+    }
+}

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -13,6 +13,11 @@ namespace Plugin.LocalNotification
         public AndroidOptions Android { get; set; } = new AndroidOptions();
 
         /// <summary>
+        /// iOS specific properties.
+        /// </summary>
+        public iOSOptions iOS { get; set; } = new iOSOptions();
+
+        /// <summary>
         /// Number of the badge displays on the Home Screen.
         /// </summary>
         public int BadgeNumber { get; set; }
@@ -45,7 +50,7 @@ namespace Plugin.LocalNotification
         public NotificationRepeat Repeats { get; set; } = NotificationRepeat.No;
 
         /// <summary>
-        /// Returning data when tapped on notification.
+        /// Returning data when tapped or received notification.
         /// </summary>
         public string ReturningData { get; set; } = string.Empty;
 

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -20,9 +20,18 @@ namespace Plugin.LocalNotification.Platform.Droid
         public event NotificationTappedEventHandler NotificationTapped;
 
         /// <inheritdoc />
+        public event NotificationReceivedEventHandler NotificationReceived;
+
+        /// <inheritdoc />
         public void OnNotificationTapped(NotificationTappedEventArgs e)
         {
             NotificationTapped?.Invoke(e);
+        }
+
+        /// <inheritdoc />
+        public void OnNotificationReceived(NotificationReceivedEventArgs e)
+        {
+            NotificationReceived?.Invoke(e);
         }
 
         /// <summary>
@@ -232,6 +241,14 @@ namespace Plugin.LocalNotification.Platform.Droid
                 notification.Defaults = NotificationDefaults.All;
             }
             _notificationManager?.Notify(request.NotificationId, notification);
+
+            var args = new NotificationReceivedEventArgs
+            {
+                Title       = request.Title,
+                Description = request.Description,
+                Data        = request.ReturningData
+            };
+            NotificationCenter.Current.OnNotificationReceived(args);
         }
 
         private static int GetIcon(string iconName)

--- a/Source/Plugin.LocalNotification/Platform/Droid/ScheduledNotificationWorker.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/ScheduledNotificationWorker.cs
@@ -92,14 +92,6 @@ namespace Plugin.LocalNotification.Platform.Droid
 
                     notification.NotifyTime = null;
                     NotificationCenter.Current.Show(notification);
-
-                    var args = new NotificationReceivedEventArgs
-                    {
-                        Title       = notification.Title,
-                        Description = notification.Description,
-                        Data        = notification.ReturningData
-                    };
-                    NotificationCenter.Current.OnNotificationReceived(args);
                 }
                 catch (Exception ex)
                 {

--- a/Source/Plugin.LocalNotification/Platform/Droid/ScheduledNotificationWorker.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/ScheduledNotificationWorker.cs
@@ -92,6 +92,14 @@ namespace Plugin.LocalNotification.Platform.Droid
 
                     notification.NotifyTime = null;
                     NotificationCenter.Current.Show(notification);
+
+                    var args = new NotificationReceivedEventArgs
+                    {
+                        Title       = notification.Title,
+                        Description = notification.Description,
+                        Data        = notification.ReturningData
+                    };
+                    NotificationCenter.Current.OnNotificationReceived(args);
                 }
                 catch (Exception ex)
                 {

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -58,12 +58,38 @@ namespace Plugin.LocalNotification.Platform.iOS
         {
             try
             {
+                var presentationOptions = UNNotificationPresentationOptions.Alert;
+                var notificationContent = notification?.Request.Content;
+
+                if (notificationContent != null)
+                {
+                    var dictionary = notificationContent.UserInfo;
+                    var args = new NotificationReceivedEventArgs
+                    {
+                        Title       = notificationContent.Title,
+                        Description = notificationContent.Body,
+                        Data        = dictionary.ContainsKey(NotificationCenter.ExtraReturnDataIos)
+                                        ? dictionary[NotificationCenter.ExtraReturnDataIos].ToString()
+                                        : ""
+                    };
+
+                    NotificationCenter.Current.OnNotificationReceived(args);
+
+
+                    if (dictionary.ContainsKey(NotificationCenter.ExtraNotificationReceivedIos))
+                    {
+                        var customOptions = dictionary[NotificationCenter.ExtraNotificationReceivedIos].ToString().ToLower();
+                        if (customOptions == "true")
+                            presentationOptions = UNNotificationPresentationOptions.None;
+                    }
+                }
+
                 if (completionHandler is null)
                 {
                     return;
                 }
 
-                completionHandler(UNNotificationPresentationOptions.Alert);
+                completionHandler(presentationOptions);
             }
             catch (Exception ex)
             {

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -16,6 +16,11 @@ namespace Plugin.LocalNotification
         /// </summary>
         public static NSString ExtraReturnDataIos => new NSString("Plugin.LocalNotification.RETURN_DATA");
 
+        /// <summary>
+        /// Presentation Key for notification received on foreground.
+        /// </summary>
+        public static NSString ExtraNotificationReceivedIos => new NSString("Plugin.LocalNotification.NOTIFICATION_RECEIVED");
+
         static NotificationCenter()
         {
             try

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -104,7 +104,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                             : returningData, NotificationCenter.ExtraReturnDataIos);
                 }
 
-                using var receivedData = new NSString(notificationRequest.iOS.HideAlertOnNotificationReceived.ToString());
+                using var receivedData = new NSString(notificationRequest.iOS.HideForegroundAlert.ToString());
                 userInfoDictionary.SetValueForKey(receivedData, NotificationCenter.ExtraNotificationReceivedIos);
 
                 using var content = new UNMutableNotificationContent

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -14,9 +14,18 @@ namespace Plugin.LocalNotification.Platform.iOS
         public event NotificationTappedEventHandler NotificationTapped;
 
         /// <inheritdoc />
+        public event NotificationReceivedEventHandler NotificationReceived;
+
+        /// <inheritdoc />
         public void OnNotificationTapped(NotificationTappedEventArgs e)
         {
             NotificationTapped?.Invoke(e);
+        }
+
+        /// <inheritdoc />
+        public void OnNotificationReceived(NotificationReceivedEventArgs e)
+        {
+            NotificationReceived?.Invoke(e);
         }
 
         /// <inheritdoc />
@@ -94,6 +103,9 @@ namespace Plugin.LocalNotification.Platform.iOS
                             ? NSString.Empty
                             : returningData, NotificationCenter.ExtraReturnDataIos);
                 }
+
+                using var receivedData = new NSString(notificationRequest.iOS.HideAlertOnNotificationReceived.ToString());
+                userInfoDictionary.SetValueForKey(receivedData, NotificationCenter.ExtraNotificationReceivedIos);
 
                 using var content = new UNMutableNotificationContent
                 {

--- a/Source/Plugin.LocalNotification/iOSOptions.cs
+++ b/Source/Plugin.LocalNotification/iOSOptions.cs
@@ -1,7 +1,14 @@
 ﻿namespace Plugin.LocalNotification
 {
+    /// <summary>
+    /// NotificationRequest for iOS
+    /// </summary>
     public class iOSOptions
     {
-        public bool HideAlertOnNotificationReceived { get; set; }
+        /// <summary>
+        /// Setting this flag will prevent iOS from displaying the default banner when a Notification is received in foreground
+        /// Default is false
+        /// </summary>
+        public bool HideForegroundAlert { get; set; }
     }
 }

--- a/Source/Plugin.LocalNotification/iOSOptions.cs
+++ b/Source/Plugin.LocalNotification/iOSOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Plugin.LocalNotification
+{
+    public class iOSOptions
+    {
+        public bool HideAlertOnNotificationReceived { get; set; }
+    }
+}


### PR DESCRIPTION
## Add a new event fired when a local notification is Notified.

Fixes #105 

While using this plugin i missed the functionality (expecially on Android) to being able to display a custom banner when a notification is received and the app is in foreground.

Push notifications plugins are exposing the `NotificationReceived` event, so why not add it to local notifications? :smile:

This PR adds the new event `NotificationReceived` with the following args:

```csharp
/// <summary>
/// Returning event when a notification is received.
/// On iOS this event is fired only when the app is in foreground
/// </summary>
public class NotificationReceivedEventArgs : EventArgs
{
    /// <summary>
    /// Returning title when a notification is received.
    /// </summary>
    public string Title { get; internal set; }

    /// <summary>
    /// Returning details when a notification is received.
    /// </summary>
    public string Description { get; internal set; } = string.Empty;

    /// <summary>
    /// Returning data when a notification is received.
    /// </summary>
    public string Data { get; internal set; }
}
```

### Notes for iOS

Due to iOS limitations, **this event will be fired only when the app is in foregound**

The following property has been added to give us the option to create a custom notification alert when a notification is received:

```csharp
/// <summary>
/// NotificationRequest for iOS
/// </summary>
public class iOSOptions
{
    /// <summary>
    /// Setting this flag will prevent iOS from displaying the default banner when a Notification is received in foreground
    /// Default is false
    /// </summary>
    public bool HideForegroundAlert { get; set; }
}
```

README and Main demos are updated aswell

