### PR TITLE
Add foreground sound option ios

### DIFF
--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml
@@ -22,7 +22,10 @@
             <Label Text="Display Alert on notification received " />
             <Switch x:Name="CustomAlert" IsToggled="false" />
         </StackLayout>
-
+        <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
+            <Label Text="Play Sound when app is in Foreground" />
+            <Switch x:Name="ForegroundSound" IsToggled="false" />
+        </StackLayout>
         <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
             <Label Text="Use Custom Sound" />
             <Switch x:Name="CustomSoundSwitch" IsToggled="false" />

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
@@ -110,7 +110,8 @@ namespace LocalNotification.Sample
                 },
                 iOS =
                 {
-                    HideForegroundAlert = CustomAlert.IsToggled
+                    HideForegroundAlert = CustomAlert.IsToggled,
+                    PlayForegroundSound = ForegroundSound.IsToggled
                 }
             };
 

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -91,15 +91,9 @@ namespace Plugin.LocalNotification.Platform.iOS
                                                                                                     .ToUpperInvariant();
                         if (customOptions == "TRUE")
                         {
-                            if (presentationOptions == UNNotificationPresentationOptions.Alert)
-                            {
-                                presentationOptions = UNNotificationPresentationOptions.Sound|UNNotificationPresentationOptions.Alert;
-                            }
-                            else
-                            {
-                                presentationOptions = UNNotificationPresentationOptions.Sound;
-                            }
-                            
+                            presentationOptions = presentationOptions == UNNotificationPresentationOptions.Alert ? 
+                                UNNotificationPresentationOptions.Sound|UNNotificationPresentationOptions.Alert :
+                                UNNotificationPresentationOptions.Sound;
                         }
                     }
                 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -84,6 +84,24 @@ namespace Plugin.LocalNotification.Platform.iOS
                             presentationOptions = UNNotificationPresentationOptions.None;
                         }
                     }
+                    
+                    if (dictionary.ContainsKey(NotificationCenter.ExtraSoundInForegroundIos))
+                    {
+                        var customOptions = dictionary[NotificationCenter.ExtraSoundInForegroundIos].ToString()
+                                                                                                    .ToUpperInvariant();
+                        if (customOptions == "TRUE")
+                        {
+                            if (presentationOptions == UNNotificationPresentationOptions.Alert)
+                            {
+                                presentationOptions = UNNotificationPresentationOptions.Sound|UNNotificationPresentationOptions.Alert;
+                            }
+                            else
+                            {
+                                presentationOptions = UNNotificationPresentationOptions.Sound;
+                            }
+                            
+                        }
+                    }
                 }
 
                 if (completionHandler is null)

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -20,6 +20,11 @@ namespace Plugin.LocalNotification
         /// Presentation Key for notification received on foreground.
         /// </summary>
         public static NSString ExtraNotificationReceivedIos => new NSString("Plugin.LocalNotification.NOTIFICATION_RECEIVED");
+        
+        /// <summary>
+        /// Key for extra playing sound in foreground.
+        /// </summary>
+        public static NSString ExtraSoundInForegroundIos => new NSString("Plugin.LocalNotification.NOTIFICATION_SOUND_FOREGROUND");
 
         static NotificationCenter()
         {

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -106,6 +106,9 @@ namespace Plugin.LocalNotification.Platform.iOS
 
                 using var receivedData = new NSString(notificationRequest.iOS.HideForegroundAlert.ToString());
                 userInfoDictionary.SetValueForKey(receivedData, NotificationCenter.ExtraNotificationReceivedIos);
+                
+                using var soundData = new NSString(notificationRequest.iOS.PlayForegroundSound.ToString());
+                userInfoDictionary.SetValueForKey(soundData, NotificationCenter.ExtraSoundInForegroundIos);
 
                 using var content = new UNMutableNotificationContent
                 {

--- a/Source/Plugin.LocalNotification/iOSOptions.cs
+++ b/Source/Plugin.LocalNotification/iOSOptions.cs
@@ -10,5 +10,11 @@
         /// Default is false
         /// </summary>
         public bool HideForegroundAlert { get; set; }
+        
+        /// <summary>
+        /// Setting this flag will enable iOS to play the default notification sound even if the app is in foreground
+        /// Default is false
+        /// </summary>
+        public bool PlayForegroundSound { get; set; }
     }
 }


### PR DESCRIPTION
### What does this PR do?
It provides the option for NotificationRequest to have iOS receive a local notification and play sound when in foreground (as issued here https://github.com/thudugala/Plugin.LocalNotification/issues/139). It also provides a new sample option to turn it on/off. Seems to be working with custom sounds as well.

##### Why are we doing this? Any context or related work?
This is a standard behavior on iOS and will come in handy for many occasions https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SchedulingandHandlingLocalNotifications.html -> Handling Notifications When Your App Is in the Foreground
