### PR TITLE
Fluent Request Builders for NotificationChannelRequest & NotificationRequest

### DIFF
--- a/Source/Plugin.LocalNotification/AndroidOptionsBuilder.cs
+++ b/Source/Plugin.LocalNotification/AndroidOptionsBuilder.cs
@@ -1,0 +1,195 @@
+﻿using System;
+
+namespace Plugin.LocalNotification
+{
+	/// <summary>
+	/// NotificationRequest for Android
+	/// </summary>
+	public class AndroidOptionsBuilder
+	{
+		private bool AutoCancel;
+		private string ChannelId;
+		private string Group;
+		private bool IsGroupSummary;
+		private int? Color;
+		private string IconName;
+		private int? LedColor;
+		private bool Ongoing;
+		private NotificationPriority Priority;
+		private bool? ProgressBarIndeterminate;
+		private int? ProgressBarMax;
+		private int? ProgressBarProgress;
+		private TimeSpan? TimeoutAfter;
+		private long[] VibrationPattern;
+
+		internal AndroidOptionsBuilder()
+		{
+			Priority = NotificationPriority.Default;
+			ChannelId = "Plugin.LocalNotification.GENERAL";
+			AutoCancel = true;
+		}
+
+		/// <summary>
+		/// Builds the request to <see cref="AndroidOptions"/>
+		/// </summary>
+		/// <returns></returns>
+		public AndroidOptions Build() => new AndroidOptions()
+		{
+			AutoCancel = AutoCancel,
+			VibrationPattern = VibrationPattern,
+			ChannelId = ChannelId,
+			Color = Color,
+			Group = Group,
+			IconName = IconName,
+			IsGroupSummary = IsGroupSummary,
+			LedColor = LedColor,
+			Ongoing = Ongoing,
+			Priority = Priority,
+			ProgressBarIndeterminate = ProgressBarIndeterminate,
+			ProgressBarMax = ProgressBarMax,
+			ProgressBarProgress = ProgressBarProgress,
+			TimeoutAfter = TimeoutAfter
+		};
+
+		/// <summary>
+		/// Sets or gets, The id of the channel. Must be unique per package. The value may be truncated if it is too lon
+		/// Use this to target the Notification Channel.
+		/// </summary>
+		public AndroidOptionsBuilder WithChannelId(string channelId)
+		{
+			ChannelId = channelId;
+			return this;
+		}
+
+		/// <summary>
+		/// Set this notification to be part of a group of notifications sharing the same key.
+		/// Grouped notifications may display in a cluster or stack on devices which support such rendering.
+		/// </summary>
+		public AndroidOptionsBuilder WithGroup(string group)
+		{
+			Group = group;
+			return this;
+		}
+
+		/// <summary>
+		/// Setting this flag will make it so the notification is automatically canceled when the user clicks it in the panel.
+		/// Default is true
+		/// </summary>
+		public AndroidOptionsBuilder WithAutoCancel(bool shouldCancel)
+		{
+			AutoCancel = shouldCancel;
+			return this;
+		}
+
+		/// <summary>
+		/// Set this notification to be the group summary for a group of notifications.
+		/// Grouped notifications may display in a cluster or stack on devices which support such rendering
+		/// </summary>
+		public AndroidOptionsBuilder WithGroupSummaryStatus(bool isGroupSummary)
+		{
+			IsGroupSummary = isGroupSummary;
+			return this;
+		}
+
+		/// <summary>
+		/// If set, the notification icon and application name will have the provided ARGB color.
+		/// </summary>
+		public AndroidOptionsBuilder WithColor(int? color)
+		{
+			Color = color;
+			return this;
+		}
+
+		/// <summary>
+		/// if Set, find the icon by name from drawable and set it has the Small Icon to use in the notification layouts.
+		/// if not set, application Icon will we used.
+		/// </summary>
+		public AndroidOptionsBuilder WithIconName(string iconName)
+		{
+			IconName = iconName;
+			return this;
+		}
+
+		/// <summary>
+		/// If set, the LED will have the provided ARGB color.
+		/// </summary>
+		public AndroidOptionsBuilder WithLedColor(int? ledColor)
+		{
+			LedColor = ledColor;
+			return this;
+		}
+
+		/// <summary>
+		/// Set whether this is an ongoing notification.
+		/// Ongoing notifications differ from regular notifications in the following ways,
+		/// Ongoing notifications are sorted above the regular notifications in the notification panel.
+		/// Ongoing notifications do not have an 'X' close button, and are not affected by the "Clear all" button.
+		/// Default is false
+		/// </summary>
+		public AndroidOptionsBuilder WithOngoingStatus(bool isOngoing)
+		{
+			Ongoing = isOngoing;
+			return this;
+		}
+
+		/// <summary>
+		/// Set the relative priority for this notification.
+		/// In Android, Only used if Android Api below 26.
+		/// Use NotificationCenter.CreateNotificationChannel when Android Api equal or above 26
+		/// </summary>
+		public AndroidOptionsBuilder WithPriority(NotificationPriority priority)
+		{
+			Priority = priority;
+			return this;
+		}
+
+		/// <summary>
+		/// Set whether this progress bar is in indeterminate mode
+		/// </summary>
+		public AndroidOptionsBuilder WithProgressBarIndeterminate(bool? progressBarIndeterminate)
+		{
+			ProgressBarIndeterminate = progressBarIndeterminate;
+			return this;
+		}
+
+		/// <summary>
+		/// Set Upper limit of this progress bar's range
+		/// </summary>
+		public AndroidOptionsBuilder WithProgressBarMax(int? progressBarMax)
+		{
+			ProgressBarMax = progressBarMax;
+			return this;
+		}
+
+		/// <summary>
+		/// Set progress bar's current level of progress
+		/// </summary>
+		public AndroidOptionsBuilder WithProgressBarProgress(int? progress)
+		{
+			ProgressBarProgress = progress;
+			return this;
+		}
+
+		/// <summary>
+		/// Specifies the time at which this notification should be canceled, if it is not already canceled.
+		/// </summary>
+		public AndroidOptionsBuilder WithTimeout(TimeSpan? timeoutAfter)
+		{
+			TimeoutAfter = timeoutAfter;
+			return this;
+		}
+
+		/// <summary>
+		/// Vibrate with a given pattern.
+		/// Pass in an array of ints that are the durations for which to turn on or off the vibrator in milliseconds.
+		/// The first value indicates the number of milliseconds to wait before turning the vibrator on.
+		/// The next value indicates the number of milliseconds for which to keep the vibrator on before turning it off.
+		/// Subsequent values alternate between durations in milliseconds to turn the vibrator off or to turn the vibrator on.
+		/// </summary>
+		public AndroidOptionsBuilder WithVibrationPattern(long[] pattern)
+		{
+			VibrationPattern = pattern;
+			return this;
+		}
+	}
+}

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -65,5 +65,18 @@ namespace Plugin.LocalNotification
         /// Title for the notification.
         /// </summary>
         public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Creates a NotificationRequestBuilder instance with specified notificationId.
+        /// </summary>
+        /// <param name="notificationId"></param>
+        /// <returns></returns>
+        public static NotificationRequestBuilder CreateBuilder(int notificationId) => new NotificationRequestBuilder(notificationId);
+
+        /// <summary>
+        /// Creates a NotificationRequestBuilder instance with default values.
+        /// </summary>
+        /// <returns></returns>
+        public static NotificationRequestBuilder CreateBuilder() => new NotificationRequestBuilder();
     }
 }

--- a/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
@@ -55,13 +55,35 @@ namespace Plugin.LocalNotification
 		}
 
 		/// <summary>
+		/// Android specific properties builder.
+		/// </summary>
+		/// <param name="builder"></param>
+		/// <returns></returns>
+		public NotificationRequestBuilder WithAndroidOptions(Func<AndroidOptionsBuilder, AndroidOptions> builder)
+		{
+			AndroidOptions = builder.Invoke(new AndroidOptionsBuilder());
+			return this;
+		}
+
+		/// <summary>
 		/// Android specific properties.
 		/// </summary>
 		/// <param name="options"></param>
 		/// <returns></returns>
 		public NotificationRequestBuilder WithAndroidOptions(AndroidOptions options)
 		{
-			AndroidOptions = options;
+			AndroidOptions = options;			
+			return this;
+		}
+
+		/// <summary>
+		/// iOS specific properties builder.
+		/// </summary>
+		/// <param name="builder"></param>
+		/// <returns></returns>
+		public NotificationRequestBuilder WithiOSOptions(Func<iOSOptionsBuilder, iOSOptions> builder)
+		{
+			iOSOptions = builder.Invoke(new iOSOptionsBuilder());
 			return this;
 		}
 

--- a/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
@@ -5,7 +5,7 @@ namespace Plugin.LocalNotification
 	/// <summary>
 	/// Notification Request Builder
 	/// </summary>
-	public class NotificationBuilder
+	public class NotificationRequestBuilder
 	{
 		private string NotificationTitle = string.Empty;
 		private string NotificationDescription = string.Empty;
@@ -20,12 +20,12 @@ namespace Plugin.LocalNotification
 		private string NotificationSound = string.Empty;
 
 		/// <summary>
-		/// A unique identifier for the request
-		/// (if identifier is not unique, a new notification request object is not created).
-		/// You can use this identifier later to cancel a request that is still pending.
+		/// Initializes NotificationRequestBuilder with the specified notification Id.
 		/// </summary>
-		/// <param name="notificationId">The unique id</param>
-		public NotificationBuilder(int notificationId)
+		/// <param name="notificationId">A unique identifier for the request
+		/// (if identifier is not unique, a new notification request object is not created).
+		/// You can use this identifier later to cancel a request that is still pending.</param>
+		public NotificationRequestBuilder(int notificationId)
 		{
 			NotificationId = notificationId;
 			AndroidOptions = new AndroidOptions();
@@ -33,11 +33,33 @@ namespace Plugin.LocalNotification
 		}
 
 		/// <summary>
+		/// Initializes NotificationRequestBuilder with default value.
+		/// </summary>
+		public NotificationRequestBuilder()
+		{
+			AndroidOptions = new AndroidOptions();
+			iOSOptions = new iOSOptions();
+		}
+
+		/// <summary>
+		/// A unique identifier for the request
+		/// (if identifier is not unique, a new notification request object is not created).
+		/// You can use this identifier later to cancel a request that is still pending.
+		/// </summary>
+		/// <param name="notificationId"></param>
+		/// <returns></returns>
+		public NotificationRequestBuilder WithNotificationId(int notificationId)
+		{
+			NotificationId = notificationId;
+			return this;
+		}
+
+		/// <summary>
 		/// Android specific properties.
 		/// </summary>
 		/// <param name="options"></param>
 		/// <returns></returns>
-		public NotificationBuilder WithAndroidOptions(AndroidOptions options)
+		public NotificationRequestBuilder WithAndroidOptions(AndroidOptions options)
 		{
 			AndroidOptions = options;
 			return this;
@@ -46,7 +68,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// iOS specific properties.
 		/// </summary>
-		public NotificationBuilder WithiOSOptions(iOSOptions options)
+		public NotificationRequestBuilder WithiOSOptions(iOSOptions options)
 		{
 			iOSOptions = options;
 			return this;
@@ -55,7 +77,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// Title for the notification.
 		/// </summary>
-		public NotificationBuilder WithTitle(string title)
+		public NotificationRequestBuilder WithTitle(string title)
 		{
 			NotificationTitle = title;
 			return this;
@@ -64,7 +86,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// Details for the notification.
 		/// </summary>
-		public NotificationBuilder WithDescription(string description)
+		public NotificationRequestBuilder WithDescription(string description)
 		{
 			NotificationDescription = description;
 			return this;
@@ -73,7 +95,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// Time to show the notification.
 		/// </summary>
-		public NotificationBuilder NotifyAt(DateTime? notificationTime)
+		public NotificationRequestBuilder NotifyAt(DateTime? notificationTime)
 		{
 			NotifyTime = notificationTime;
 			return this;
@@ -82,7 +104,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// Number of the badge displays on the Home Screen.
 		/// </summary>
-		public NotificationBuilder WithBadgeCount(int count)
+		public NotificationRequestBuilder WithBadgeCount(int count)
 		{
 			BadgeNumberCount = count;
 			return this;
@@ -91,7 +113,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// Returning data when tapped or received notification.
 		/// </summary>
-		public NotificationBuilder WithReturningData(string serilizedReturningData)
+		public NotificationRequestBuilder WithReturningData(string serilizedReturningData)
 		{
 			ReturningData = serilizedReturningData;
 			return this;
@@ -102,7 +124,7 @@ namespace Plugin.LocalNotification
 		/// In Android, Only used if Android Api below 26.
 		/// Use NotificationCenter.CreateNotificationChannel when Android Api equal or above 26
 		/// </summary>
-		public NotificationBuilder WithSound(string fileName)
+		public NotificationRequestBuilder WithSound(string fileName)
 		{
 			NotificationSound = fileName;
 			return this;
@@ -111,7 +133,7 @@ namespace Plugin.LocalNotification
 		/// <summary>
 		/// if Repeats = TimeInterval, then repeat again after specified amount of time elapses
 		/// </summary>
-		public NotificationBuilder SetNotificationRepeatInterval(NotificationRepeat repeatInterval, TimeSpanExt? timeSpanExt)
+		public NotificationRequestBuilder SetNotificationRepeatInterval(NotificationRepeat repeatInterval, TimeSpanExt? timeSpanExt)
 		{
 			RepeatInterval = repeatInterval;
 			RepeatSpan = timeSpanExt;

--- a/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
@@ -1,0 +1,140 @@
+﻿using System;
+
+namespace Plugin.LocalNotification
+{
+	/// <summary>
+	/// Notification Request Builder
+	/// </summary>
+	public class NotificationBuilder
+	{
+		private string NotificationTitle = string.Empty;
+		private string NotificationDescription = string.Empty;
+		private DateTime? NotifyTime;
+		private int NotificationId;
+		private int BadgeNumberCount;
+		private string ReturningData = string.Empty;
+		private AndroidOptions AndroidOptions;
+		private iOSOptions iOSOptions;
+		private NotificationRepeat RepeatInterval = NotificationRepeat.No;
+		private TimeSpanExt? RepeatSpan;
+		private string NotificationSound = string.Empty;
+
+		/// <summary>
+		/// A unique identifier for the request
+		/// (if identifier is not unique, a new notification request object is not created).
+		/// You can use this identifier later to cancel a request that is still pending.
+		/// </summary>
+		/// <param name="notificationId">The unique id</param>
+		public NotificationBuilder(int notificationId)
+		{
+			NotificationId = notificationId;
+			AndroidOptions = new AndroidOptions();
+			iOSOptions = new iOSOptions();
+		}
+
+		/// <summary>
+		/// Android specific properties.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		public NotificationBuilder WithAndroidOptions(AndroidOptions options)
+		{
+			AndroidOptions = options;
+			return this;
+		}
+
+		/// <summary>
+		/// iOS specific properties.
+		/// </summary>
+		public NotificationBuilder WithiOSOptions(iOSOptions options)
+		{
+			iOSOptions = options;
+			return this;
+		}
+
+		/// <summary>
+		/// Title for the notification.
+		/// </summary>
+		public NotificationBuilder WithTitle(string title)
+		{
+			NotificationTitle = title;
+			return this;
+		}
+
+		/// <summary>
+		/// Details for the notification.
+		/// </summary>
+		public NotificationBuilder WithDescription(string description)
+		{
+			NotificationDescription = description;
+			return this;
+		}
+
+		/// <summary>
+		/// Time to show the notification.
+		/// </summary>
+		public NotificationBuilder NotifyAt(DateTime? notificationTime)
+		{
+			NotifyTime = notificationTime;
+			return this;
+		}
+
+		/// <summary>
+		/// Number of the badge displays on the Home Screen.
+		/// </summary>
+		public NotificationBuilder WithBadgeCount(int count)
+		{
+			BadgeNumberCount = count;
+			return this;
+		}
+
+		/// <summary>
+		/// Returning data when tapped or received notification.
+		/// </summary>
+		public NotificationBuilder WithReturningData(string serilizedReturningData)
+		{
+			ReturningData = serilizedReturningData;
+			return this;
+		}
+
+		/// <summary>
+		/// Sound file name for the notification.
+		/// In Android, Only used if Android Api below 26.
+		/// Use NotificationCenter.CreateNotificationChannel when Android Api equal or above 26
+		/// </summary>
+		public NotificationBuilder WithSound(string fileName)
+		{
+			NotificationSound = fileName;
+			return this;
+		}
+
+		/// <summary>
+		/// if Repeats = TimeInterval, then repeat again after specified amount of time elapses
+		/// </summary>
+		public NotificationBuilder SetNotificationRepeatInterval(NotificationRepeat repeatInterval, TimeSpanExt? timeSpanExt)
+		{
+			RepeatInterval = repeatInterval;
+			RepeatSpan = timeSpanExt;
+			return this;
+		}
+
+		/// <summary>
+		/// Creates the notification request
+		/// </summary>
+		/// <returns>The notification request</returns>
+		public NotificationRequest Create() => new NotificationRequest()
+		{
+			Android = AndroidOptions,
+			iOS = iOSOptions,
+			BadgeNumber = BadgeNumberCount,
+			Description = NotificationDescription,
+			NotificationId = NotificationId,
+			Repeats = RepeatInterval,
+			NotifyRepeatInterval = RepeatSpan,
+			NotifyTime = NotifyTime,
+			ReturningData = ReturningData,
+			Sound = NotificationSound,
+			Title = NotificationTitle
+		};
+	}
+}

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
@@ -141,7 +141,7 @@ namespace Plugin.LocalNotification
                 Description = request.Description,
                 Group = request.Group,
                 LightColor = request.LightColor,
-                LockscreenVisibility = request.LockscreenVisibility,
+                LockscreenVisibility = request.LockscreenVisibility,                
             };
             var soundUri = GetSoundUri(request.Sound);
             if (soundUri != null)
@@ -162,6 +162,7 @@ namespace Plugin.LocalNotification
             channel.SetShowBadge(request.ShowBadge);
             channel.EnableLights(request.EnableLights);
             channel.EnableVibration(request.EnableVibration);
+            channel.SetBypassDnd(request.CanBypassDND);
 
             notificationManager.CreateNotificationChannel(channel);
         }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
@@ -178,7 +178,7 @@ namespace Plugin.LocalNotification
             channel.SetShowBadge(request.ShowBadge);
             channel.EnableLights(request.EnableLights);
             channel.EnableVibration(request.EnableVibration);
-            channel.SetBypassDnd(request.CanBypassDND);
+            channel.SetBypassDnd(request.CanBypassDnd);
 
             notificationManager.CreateNotificationChannel(channel);
         }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationCenter.cs
@@ -68,6 +68,16 @@ namespace Plugin.LocalNotification
         }
 
         /// <summary>
+        /// Create Notification Channel Group with builder when API >= 26.
+        /// If you'd like to further organize the appearance of your channels in the settings UI, you can create channel groups.
+        /// This is a good idea when your app supports multiple user accounts (such as for work profiles),
+        /// so you can create a notification channel group for each account.
+        /// This way, users can easily identify and control multiple notification channels that have identical names.
+        /// </summary>
+        /// <param name="builder"></param>
+        public static void CreateNotificationChannelGroup(Func<NotificationChannelGroupRequestBuilder, NotificationChannelGroupRequest> builder) => CreateNotificationChannelGroup(builder.Invoke(new NotificationChannelGroupRequestBuilder()));
+
+        /// <summary>
         /// Create Notification Channel Group when API >= 26.
         /// If you'd like to further organize the appearance of your channels in the settings UI, you can create channel groups.
         /// This is a good idea when your app supports multiple user accounts (such as for work profiles),
@@ -102,6 +112,12 @@ namespace Plugin.LocalNotification
         }
 
         /// <summary>
+        /// Create Notification Channel with builder when API >= 26.
+        /// </summary>
+        /// <param name="builder"></param>
+        public static void CreateNotificationChannel(Func<NotificationChannelRequestBuilder, NotificationChannelRequest> builder) => CreateNotificationChannel(builder.Invoke(new NotificationChannelRequestBuilder()));
+
+        /// <summary>
         /// Create Notification Channel when API >= 26.
         /// </summary>
         /// <param name="request"></param>
@@ -112,8 +128,8 @@ namespace Plugin.LocalNotification
                 return;
             }
 
-            if (!(Application.Context.GetSystemService(Context.NotificationService) is NotificationManager
-                notificationManager))
+            if (Application.Context.GetSystemService(Context.NotificationService) is not NotificationManager
+                notificationManager)
             {
                 return;
             }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequest.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequest.cs
@@ -14,5 +14,16 @@
         ///
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Default ctor
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="name"></param>
+        public NotificationChannelGroupRequest(string group, string name)
+		{
+            Group = group;
+            Name = name;
+		}
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequestBuilder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.LocalNotification.Platform.Droid
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class NotificationChannelGroupRequestBuilder
+	{
+		private string Group;
+		private string Name;
+
+		internal NotificationChannelGroupRequestBuilder()
+		{
+
+		}
+
+		/// <summary>
+		/// Builds the request to <see cref="NotificationChannelGroupRequest"/>
+		/// </summary>
+		/// <returns></returns>
+		public NotificationChannelGroupRequest Build() => new NotificationChannelGroupRequest(Group, Name);
+
+		/// <summary>
+		/// Sets the Group
+		/// </summary>
+		/// <param name="group"></param>
+		/// <returns></returns>
+		public NotificationChannelGroupRequestBuilder WithGroup(string group)
+		{
+			Group = group;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the Name
+		/// </summary>
+		/// <param name="name"></param>
+		/// <returns></returns>
+		public NotificationChannelGroupRequestBuilder WithName(string name)
+		{
+			Name = name;
+			return this;
+		}
+	}
+}

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
@@ -71,5 +71,10 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// Sets or gets, Sets whether notification posted to this channel should vibrate. The vibration pattern can be set with VibrationPattern
         /// </summary>
         public bool EnableVibration { get; set; } = true;
+
+        /// <summary>
+        /// Sets or gets, Sets whether notification posted to this channel can bypass DND (Do Not Distrub) mode.
+        /// </summary>
+        public bool CanBypassDND { get; set; } = false;
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
@@ -76,5 +76,17 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// Sets or gets, Sets whether notification posted to this channel can bypass DND (Do Not Distrub) mode.
         /// </summary>
         public bool CanBypassDND { get; set; } = false;
+
+        /// <summary>
+        /// Creates a ChannelRequestBuilder with default values.
+        /// </summary>
+        /// <returns></returns>
+        public static NotificationChannelRequestBuilder CreateBuilder() => new NotificationChannelRequestBuilder();
+
+        /// <summary>
+        /// Creates a ChannelRequestBuilder with specified channelId.
+        /// </summary>
+        /// <returns></returns>
+        public static NotificationChannelRequestBuilder CreateBuilder(string channelId) => new NotificationChannelRequestBuilder(channelId);
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequest.cs
@@ -75,7 +75,7 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// <summary>
         /// Sets or gets, Sets whether notification posted to this channel can bypass DND (Do Not Distrub) mode.
         /// </summary>
-        public bool CanBypassDND { get; set; } = false;
+        public bool CanBypassDnd { get; set; } = false;
 
         /// <summary>
         /// Creates a ChannelRequestBuilder with default values.

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
@@ -43,6 +43,15 @@ namespace Plugin.LocalNotification.Platform.Droid
 		}
 
 		/// <summary>
+		/// Sets, the channel id.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithChannelId(string channelId)
+		{
+			ChannelId = channelId ?? NotificationCenter.DefaultChannelId;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets, the level of interruption of this notification channel.
 		/// </summary>
 		public NotificationChannelRequestBuilder WithImportance(NotificationImportance importance)

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
@@ -164,7 +164,7 @@ namespace Plugin.LocalNotification.Platform.Droid
 		/// Creates NotificationChannelRequest from this builder.
 		/// </summary>
 		/// <returns>The notification channel request</returns>
-		public NotificationChannelRequest Create()
+		public NotificationChannelRequest Build()
 		{
 			return new NotificationChannelRequest()
 			{

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
@@ -23,7 +23,7 @@ namespace Plugin.LocalNotification.Platform.Droid
 		private bool ShowBadge = true;
 		private bool EnableLights = true;
 		private bool EnableVibration = true;
-		private bool BypassDND = false;
+		private bool BypassDnd = false;
 
 		/// <summary>
 		/// Initializes builder with the specified channelID.
@@ -154,9 +154,9 @@ namespace Plugin.LocalNotification.Platform.Droid
 		/// <summary>
 		/// Sets, Sets whether notification posted to this channel can bypass DND (Do Not Distrub) mode.
 		/// </summary>
-		public NotificationChannelRequestBuilder ShouldBypassDND(bool value)
+		public NotificationChannelRequestBuilder ShouldBypassDnd(bool value)
 		{
-			BypassDND = value;
+			BypassDnd = value;
 			return this;
 		}
 
@@ -180,7 +180,7 @@ namespace Plugin.LocalNotification.Platform.Droid
 				ShowBadge = ShowBadge,
 				Sound = SoundFile,
 				VibrationPattern = VibrationPattern,
-				CanBypassDND = BypassDND
+				CanBypassDnd = BypassDnd
 			};
 		}
 	}

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelRequestBuilder.cs
@@ -1,0 +1,178 @@
+﻿using Android.App;
+using Android.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.LocalNotification.Platform.Droid
+{
+	/// <summary>
+	/// Notification channel request builder
+	/// </summary>
+	public class NotificationChannelRequestBuilder
+	{
+		private NotificationImportance Importance = NotificationImportance.Default;
+		private string ChannelId;
+		private string Name;
+		private string Description;
+		private string Group;
+		private Color LightColor;
+		private string SoundFile;
+		private long[] VibrationPattern;
+		private NotificationVisibility LockscreenVisibility = NotificationVisibility.Secret;
+		private bool ShowBadge = true;
+		private bool EnableLights = true;
+		private bool EnableVibration = true;
+		private bool BypassDND = false;
+
+		/// <summary>
+		/// Initializes builder with the specified channelID.
+		/// </summary>
+		/// <param name="channelId">The channel id</param>
+		public NotificationChannelRequestBuilder(string channelId)
+		{
+			ChannelId = channelId ?? NotificationCenter.DefaultChannelId;
+		}
+
+		/// <summary>
+		/// Initializes builder with the default channel id.
+		/// </summary>
+		public NotificationChannelRequestBuilder()
+		{
+			ChannelId = NotificationCenter.DefaultChannelId;
+		}
+
+		/// <summary>
+		/// Sets, the level of interruption of this notification channel.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithImportance(NotificationImportance importance)
+		{
+			Importance = importance;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, the user visible name of this channel, default is General.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithName(string name)
+		{
+			Name = name ?? "General";
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, the user visible description of this channel.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithDescription(string description)
+		{
+			Description = description;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, what group this channel belongs to.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithGroup(string groupName)
+		{
+			Group = groupName;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, the notification light color for notifications posted to this channel,
+		/// if the device supports that feature
+		/// </summary>
+		public NotificationChannelRequestBuilder WithLightColor(Color lightColor)
+		{
+			LightColor = lightColor;
+			return this;
+		}
+
+		/// <summary>
+		/// Sound file name for the notification.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithCustomSound(string soundFilePath)
+		{
+			SoundFile = soundFilePath;
+			return this;
+		}
+
+		/// <summary>
+		/// Only modifiable before the channel is submitted.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithCustomVibrationPattern(long[] vibrationPattern)
+		{
+			VibrationPattern = vibrationPattern;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, whether or not notifications posted to this channel are shown on the lockscreen in full or redacted form.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithLockscreenVisibility(NotificationVisibility lockscreenVisibility)
+		{
+			LockscreenVisibility = lockscreenVisibility;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, Sets whether notifications posted to this channel can appear as application icon badges in a Launcher.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithBadges(bool value)
+		{
+			ShowBadge = value;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, Sets whether notifications posted to this channel should display notification lights, on devices that support that feature.
+		/// </summary>
+		public NotificationChannelRequestBuilder WithLights(bool value)
+		{
+			EnableLights = value;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, Sets whether notification posted to this channel should vibrate. The vibration pattern can be set with VibrationPattern
+		/// </summary>
+		public NotificationChannelRequestBuilder WithVibration(bool value)
+		{
+			EnableVibration = value;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets, Sets whether notification posted to this channel can bypass DND (Do Not Distrub) mode.
+		/// </summary>
+		public NotificationChannelRequestBuilder ShouldBypassDND(bool value)
+		{
+			BypassDND = value;
+			return this;
+		}
+
+		/// <summary>
+		/// Creates NotificationChannelRequest from this builder.
+		/// </summary>
+		/// <returns>The notification channel request</returns>
+		public NotificationChannelRequest Create()
+		{
+			return new NotificationChannelRequest()
+			{
+				Id = ChannelId,
+				Description = Description,
+				EnableLights = EnableLights,
+				EnableVibration = EnableVibration,
+				Group = Group,
+				Importance = Importance,
+				LightColor = LightColor,
+				LockscreenVisibility = LockscreenVisibility,
+				Name = Name,
+				ShowBadge = ShowBadge,
+				Sound = SoundFile,
+				VibrationPattern = VibrationPattern,
+				CanBypassDND = BypassDND
+			};
+		}
+	}
+}

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -102,8 +102,11 @@ namespace Plugin.LocalNotification.Platform.Droid
         }
 
         /// <inheritdoc />
+        public void Show(Func<NotificationRequestBuilder, NotificationRequest> builder) => Show(builder.Invoke(new NotificationRequestBuilder()));
+
+        /// <inheritdoc />
         public void Show(NotificationRequest notificationRequest)
-        {
+        {            
             try
             {
                 if (Build.VERSION.SdkInt < BuildVersionCodes.IceCreamSandwich)

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -107,6 +107,22 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// <inheritdoc />
         public void Show(NotificationRequest notificationRequest)
         {            
+            Show((builder) => builder
+                .NotifyAt(DateTime.Now.AddSeconds(10))
+                .WithDescription("SampleDescription")
+                .WithNotificationId(10)
+                .WithTitle("SampleTitle")
+                .WithAndroidOptions((android) => android
+                    .WithAutoCancel(true)
+                    .WithChannelId("General")
+                    .WithOngoingStatus(true)
+                    .WithPriority(NotificationPriority.High)
+                    .Build())
+                .WithiOSOptions((ios) => ios
+                    .WithForegroundAlertStatus(false)
+                    .WithForegroundSoundStatus(true)
+                    .Build())
+                .Create());
             try
             {
                 if (Build.VERSION.SdkInt < BuildVersionCodes.IceCreamSandwich)

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -107,22 +107,6 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// <inheritdoc />
         public void Show(NotificationRequest notificationRequest)
         {            
-            Show((builder) => builder
-                .NotifyAt(DateTime.Now.AddSeconds(10))
-                .WithDescription("SampleDescription")
-                .WithNotificationId(10)
-                .WithTitle("SampleTitle")
-                .WithAndroidOptions((android) => android
-                    .WithAutoCancel(true)
-                    .WithChannelId("General")
-                    .WithOngoingStatus(true)
-                    .WithPriority(NotificationPriority.High)
-                    .Build())
-                .WithiOSOptions((ios) => ios
-                    .WithForegroundAlertStatus(false)
-                    .WithForegroundSoundStatus(true)
-                    .Build())
-                .Create());
             try
             {
                 if (Build.VERSION.SdkInt < BuildVersionCodes.IceCreamSandwich)

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -72,6 +72,9 @@ namespace Plugin.LocalNotification.Platform.iOS
         }
 
         /// <inheritdoc />
+        public void Show(Func<NotificationRequestBuilder, NotificationRequest> builder) => Show(builder.Invoke(new NotificationRequestBuilder()));
+
+        /// <inheritdoc />
         public async void Show(NotificationRequest notificationRequest)
         {
             UNNotificationTrigger trigger = null;

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -30,6 +30,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <CodeAnalysisRuleSet>Plugin.LocalNotification.ruleset</CodeAnalysisRuleSet>
+
+    <AssemblyVersion>5.2.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -30,8 +30,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <CodeAnalysisRuleSet>Plugin.LocalNotification.ruleset</CodeAnalysisRuleSet>
-
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Plugin.LocalNotification/iOSOptionsBuilder.cs
+++ b/Source/Plugin.LocalNotification/iOSOptionsBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.LocalNotification
+{
+	/// <summary>
+	/// NotificationRequest for iOS
+	/// </summary>
+	public class iOSOptionsBuilder
+	{
+		private bool HideForgroundAlert;
+		private bool PlayForegroundSound;
+
+		internal iOSOptionsBuilder()
+		{
+
+		}
+
+		/// <summary>
+		/// Builds the request to <see cref="iOSOptions"/>
+		/// </summary>
+		/// <returns></returns>
+		public iOSOptions Build() => new iOSOptions()
+		{
+			HideForegroundAlert = HideForgroundAlert,
+			PlayForegroundSound = PlayForegroundSound
+		};
+
+		/// <summary>
+		/// Setting this flag will prevent iOS from displaying the default banner when a Notification is received in foreground
+		/// Default is false
+		/// </summary>
+		public iOSOptionsBuilder WithForegroundAlertStatus(bool shouldHideForegroundAlert)
+		{
+			HideForgroundAlert = shouldHideForegroundAlert;
+			return this;
+		}
+
+		/// <summary>
+		/// Setting this flag will enable iOS to play the default notification sound even if the app is in foreground
+		/// Default is false
+		/// </summary>
+		public iOSOptionsBuilder WithForegroundSoundStatus(bool shouldPlayForegroundSound)
+		{
+			PlayForegroundSound = shouldPlayForegroundSound;
+			return this;
+		}
+	}
+}


### PR DESCRIPTION
closes #141

### What does this PR do?
Implement basic fluent pattern for creating a NotificationChannel and a NotificationRequest.
Also adds a boolean value for BypassDND option.

EDIT:
Added Fluent builder for AndroidOptions & iOSOptions,
Added a better way to create the builder on Show(...)
in current context, builder can be called like so:
```cs
 Show((builder) => builder
                .NotifyAt(DateTime.Now.AddSeconds(10))
                .WithDescription("SampleDescription")
                .WithNotificationId(10)
                .WithTitle("SampleTitle")
                .WithAndroidOptions((android) => android
                    .WithAutoCancel(true)
                    .WithChannelId("General")
                    .WithOngoingStatus(true)
                    .WithPriority(NotificationPriority.High)
                    .Build())
                .WithiOSOptions((ios) => ios
                    .WithForegroundAlertStatus(false)
                    .WithForegroundSoundStatus(true)
                    .Build())
                .Create());
```
And to create a NotificationChannel: 
```cs
 CreateNotificationChannel((builder) => builder
                .ShouldBypassDND(false)
                .WithBadges(true)
                .WithChannelId("General")
                .Build());
```
And for NotificationChannelGroup:
```cs
 CreateNotificationChannelGroup((builder) => builder
                .WithGroup("Group")
                .WithName("Name")
                .Build());
```
##### Why are we doing this? Any context or related work?
For this opened issue #141