### PR TITLE
Update readme samples with new Request Builder models & Implement Show() and Cancel() on NotificationRequest #148

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,39 @@ var notification = new NotificationRequest
 NotificationCenter.Current.Show(notification);
 ```
 
+### Or with Notification Request Builder
+
+```csharp
+ NotificationCenter.Current.Show((notification) => notification
+                        .NotifyAt(DateTime.Now.AddSeconds(30)) // Used for Scheduling local notification, if not specified notification will show immediately.
+                        .WithTitle("Test Title")
+                        .WithDescription("Test Description")
+                        .WithReturningData("Dummy Data") // Returning data when tapped on notification.
+                        .WithNotificationId(100)
+                        .Create());
+```
+
+### With platform specific options
+```csharp
+NotificationCenter.Current.Show((notification) => notification
+                    .NotifyAt(DateTime.Now.AddSeconds(30))
+                    .WithAndroidOptions((android) => android
+                         .WithAutoCancel(true)
+                         .WithChannelId("General")
+                         .WithPriority(NotificationPriority.High)
+                         .WithOngoingStatus(true)
+                         .Build())
+                    .WithiOSOptions((ios) => ios
+                        .WithForegroundAlertStatus(true)
+                        .WithForegroundSoundStatus(true)
+                        .Build())
+                    .WithReturningData("Dummy Data")
+                    .WithTitle("Test Title")
+                    .WithDescription("Test Description")
+                    .WithNotificationId(100)
+                    .Create());
+```
+
 ### Receive local notification tap event
 
 ```csharp

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Plugin.LocalNotification
 {
@@ -78,5 +79,18 @@ namespace Plugin.LocalNotification
         /// </summary>
         /// <returns></returns>
         public static NotificationRequestBuilder CreateBuilder() => new ();
+
+        /// <summary>
+        /// Directly call Show() on this <see cref="NotificationRequest"/> instance.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> Show() => NotificationCenter.Current.Show(this);
+
+        /// <summary>
+        /// Directly call Cancel(...) on this <see cref="NotificationRequest"/> instance.
+        /// <para>Notification Id set for this instance will be used to cancel this notification.</para>
+        /// </summary>
+        /// <returns></returns>
+        public bool Cancel() => NotificationCenter.Current.Cancel(this.NotificationId);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Updates the readme sample with the request builder type.

##### Why are we doing this? Any context or related work?
I just thought it might be good idea to add it in readme as it is implemented in source.