### PR TITLE
CreateNotificationChannel() method not found fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,4 @@ ASALocalRun/
 /Sample/NuGet v302/Sample.Android/Resources/Resource.designer.cs
 /Sample/NuGet/LocalNotification.Sample.Android/Resources/Resource.designer.cs
 /Sample/NuGet v500P01/LocalNotification.Sample.Android/Resources/Resource.Designer.cs
+/Sample/NuGet v414/LocalNotification.Sample.Android/Resources

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequest.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationChannelGroupRequest.cs
@@ -16,7 +16,7 @@
         public string Name { get; set; }
 
         /// <summary>
-        /// Default ctor
+        /// Constructor to pass values directly
         /// </summary>
         /// <param name="group"></param>
         /// <param name="name"></param>
@@ -24,6 +24,14 @@
         {
             Group = group;
             Name = name;
+        }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public NotificationChannelGroupRequest()
+        {
+
         }
     }
 }

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;MonoAndroid11.0;Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;MonoAndroid10.0;Xamarin.iOS10</TargetFrameworks>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>


### PR DESCRIPTION
### What does this PR do?
This PR fixes `NotificationCenter.CreateNotificationChannel();` not found bug on the latest builder (6.0.0)
This bug was pointed out in 2 issues, #159  #160 
marcominerva pointed out the fix on #160  issue, just created a PR for that.
fixes #159  #160

also, there was a missing constructor on `NotificationChannelGroupRequest` class which forced you to use the parameterized `NotificationChannelGroupRequest(string group, string name)` constructor. Added a default constructor `NotificationChannelGroupRequest()` like before.
