### PR TITLE
iOS notification action support and support for Subtitles 

### DIFF
--- a/Source/Plugin.LocalNotification/ActionTypes.cs
+++ b/Source/Plugin.LocalNotification/ActionTypes.cs
@@ -1,0 +1,11 @@
+using System;
+namespace Plugin.LocalNotification
+{
+    public enum ActionTypes
+    {
+        Default,
+        Destructive,
+        AuthenticationRequired,
+        Foreground
+    }
+}

--- a/Source/Plugin.LocalNotification/INotificationService.cs
+++ b/Source/Plugin.LocalNotification/INotificationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Plugin.LocalNotification
@@ -52,5 +53,16 @@ namespace Plugin.LocalNotification
         /// </summary>
         /// <param name="notificationRequest"></param>
         Task<bool> Show(NotificationRequest notificationRequest);
+
+
+        /// <summary>
+        /// Storage for actions
+        /// </summary>
+        Dictionary<string, NotificationAction> NotificationActions { get; }
+
+        /// <summary>
+        /// Register notification categories and their corresponding actions
+        /// </summary>
+        void RegisterCategories(NotificationCategory[] notificationCategories);
     }
 }

--- a/Source/Plugin.LocalNotification/NotificationAction.cs
+++ b/Source/Plugin.LocalNotification/NotificationAction.cs
@@ -1,0 +1,17 @@
+using System;
+namespace Plugin.LocalNotification
+{
+    public class NotificationAction
+    {
+        public string Identifier { get; }
+        public string Title { get; }
+        public Action<int, string> Handler { get; }
+
+        public NotificationAction(string identifier, string title, Action<int, string> handler)
+        {
+            Identifier = identifier;
+            Title = title;
+            Handler = handler;
+        }
+    }
+}

--- a/Source/Plugin.LocalNotification/NotificationAction.cs
+++ b/Source/Plugin.LocalNotification/NotificationAction.cs
@@ -6,12 +6,14 @@ namespace Plugin.LocalNotification
         public string Identifier { get; }
         public string Title { get; }
         public Action<int, string> Handler { get; }
+        public ActionTypes ActionType { get; }
 
-        public NotificationAction(string identifier, string title, Action<int, string> handler)
+        public NotificationAction(string identifier, string title, Action<int, string> handler, ActionTypes actionType = ActionTypes.Default)
         {
             Identifier = identifier;
             Title = title;
             Handler = handler;
+            ActionType = actionType;
         }
     }
 }

--- a/Source/Plugin.LocalNotification/NotificationCategory.cs
+++ b/Source/Plugin.LocalNotification/NotificationCategory.cs
@@ -9,12 +9,12 @@ namespace Plugin.LocalNotification
     /// </summary>
     public class NotificationCategory
     {
-        public NotificationCategory(string identifier)
+        public NotificationCategory(NotificationCategoryTypes type)
         {
-            Identifier = identifier;
+            Type = type;
         }
 
-        public string Identifier { get; }
+        public NotificationCategoryTypes Type { get; }
 
         public NotificationAction[] NotificationActions { get; set; }
     }

--- a/Source/Plugin.LocalNotification/NotificationCategory.cs
+++ b/Source/Plugin.LocalNotification/NotificationCategory.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Plugin.LocalNotification
+{
+
+    /// <summary>
+    /// Categories serve as the container for actions
+    /// </summary>
+    public class NotificationCategory
+    {
+        public NotificationCategory(string identifier)
+        {
+            Identifier = identifier;
+        }
+
+        public string Identifier { get; }
+
+        public NotificationAction[] NotificationActions { get; set; }
+    }
+}

--- a/Source/Plugin.LocalNotification/NotificationCategoryTypes.cs
+++ b/Source/Plugin.LocalNotification/NotificationCategoryTypes.cs
@@ -1,0 +1,12 @@
+using System;
+namespace Plugin.LocalNotification
+{
+    public enum NotificationCategoryTypes
+    {
+        None,
+        Alarm,
+        Reminder,
+        Event,
+        System
+    }
+}

--- a/Source/Plugin.LocalNotification/NotificationCategoryTypes.cs
+++ b/Source/Plugin.LocalNotification/NotificationCategoryTypes.cs
@@ -7,6 +7,8 @@ namespace Plugin.LocalNotification
         Alarm,
         Reminder,
         Event,
-        System
+        System,
+        Error,
+        StopWatch
     }
 }

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -58,6 +58,11 @@ namespace Plugin.LocalNotification
         public string Title { get; set; } = string.Empty;
 
         /// <summary>
+        /// Notification category for  actions
+        /// </summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>
         /// Creates a NotificationRequestBuilder instance with specified notificationId.
         /// </summary>
         /// <param name="notificationId"></param>

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -58,6 +58,11 @@ namespace Plugin.LocalNotification
         public string Title { get; set; } = string.Empty;
 
         /// <summary>
+        /// Subtitle for the notification.
+        /// </summary>
+        public string Subtitle { get; set; } = string.Empty;
+
+        /// <summary>
         /// Notification category for  actions
         /// </summary>
         public string Category { get; set; } = string.Empty;

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -65,7 +65,7 @@ namespace Plugin.LocalNotification
         /// <summary>
         /// Notification category for  actions
         /// </summary>
-        public string Category { get; set; } = string.Empty;
+        public NotificationCategoryTypes Category { get; set; } = NotificationCategoryTypes.None;
 
         /// <summary>
         /// Creates a NotificationRequestBuilder instance with specified notificationId.

--- a/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequestBuilder.cs
@@ -14,6 +14,7 @@ namespace Plugin.LocalNotification
         private int NotificationId;
         private string NotificationSound = string.Empty;
         private string NotificationTitle = string.Empty;
+        private string NotificationSubtitle = string.Empty;
         private string ReturningData = string.Empty;
         private NotificationRequestSchedule Schedule;
 
@@ -179,6 +180,15 @@ namespace Plugin.LocalNotification
         public NotificationRequestBuilder WithTitle(string title)
         {
             NotificationTitle = title;
+            return this;
+        }
+
+        /// <summary>
+        /// Title for the notification.
+        /// </summary>
+        public NotificationRequestBuilder WithSubtitle(string subtitle)
+        {
+            NotificationSubtitle = subtitle;
             return this;
         }
     }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -165,6 +165,10 @@ namespace Plugin.LocalNotification.Platform.Droid
 
             using var builder = new NotificationCompat.Builder(Application.Context, request.Android.ChannelId);
             builder.SetContentTitle(request.Title);
+
+            builder.SetSubText(request.Subtitle);
+
+
             builder.SetContentText(request.Description);
             using (var bigTextStyle = new NotificationCompat.BigTextStyle())
             {
@@ -183,6 +187,12 @@ namespace Plugin.LocalNotification.Platform.Droid
                     builder.SetGroupSummary(true);
                 }
             }
+
+            if (!string.IsNullOrEmpty(request.Category))
+            {
+                builder.SetCategory(request.Category);
+            }
+
 
             if (Build.VERSION.SdkInt < BuildVersionCodes.O)
             {

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -1,11 +1,14 @@
 ﻿using Android.App;
 using Android.Content;
 using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.OS;
 using AndroidX.Core.App;
+using AndroidX.Core.Graphics.Drawable;
 using AndroidX.Work;
 using Java.Util.Concurrent;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 
@@ -23,6 +26,8 @@ namespace Plugin.LocalNotification.Platform.Droid
         ///
         /// </summary>
         protected readonly WorkManager WorkManager;
+
+        public Dictionary<string, NotificationAction> NotificationActions { get; } = new Dictionary<string, NotificationAction>();
 
         /// <inheritdoc />
         public event NotificationTappedEventHandler NotificationTapped;
@@ -193,7 +198,6 @@ namespace Plugin.LocalNotification.Platform.Droid
                 builder.SetCategory(request.Category);
             }
 
-
             if (Build.VERSION.SdkInt < BuildVersionCodes.O)
             {
                 builder.SetPriority((int)request.Android.Priority);
@@ -249,6 +253,17 @@ namespace Plugin.LocalNotification.Platform.Droid
             var pendingIntent = PendingIntent.GetActivity(Application.Context, request.NotificationId, notificationIntent,
                 PendingIntentFlags.CancelCurrent);
             builder.SetContentIntent(pendingIntent);
+
+
+            if (NotificationActions.Count > 0)
+            {
+                foreach(var notificationAction in NotificationActions)
+                {
+                    var action = new NotificationCompat.Action(GetIcon(request.Android.IconSmallName), new Java.Lang.String(notificationAction.Value.Title), pendingIntent);
+
+                    builder.AddAction(action);
+                }
+            }
 
             var notification = builder.Build();
             if (Build.VERSION.SdkInt < BuildVersionCodes.O &&
@@ -342,6 +357,21 @@ namespace Plugin.LocalNotification.Platform.Droid
         protected static void Log(string message)
         {
             Android.Util.Log.Info(Application.Context.PackageName, message);
+        }
+
+        public void RegisterCategories(NotificationCategory[] notificationCategories)
+        {
+            foreach(var category in notificationCategories)
+            {
+                RegisterActions(category.NotificationActions);
+            }
+        }
+        private void RegisterActions(NotificationAction[] notificationActions)
+        {
+            foreach(var action in notificationActions)
+            {
+                NotificationActions.Add(action.Identifier, action);
+            }
         }
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -253,6 +253,8 @@ namespace Plugin.LocalNotification.Platform.Droid
             builder.SetContentIntent(pendingIntent);
 
 
+            // @TODO pendingIntent needs to be routed to handler
+            /*
             if (NotificationActions.Count > 0)
             {
                 foreach(var notificationAction in NotificationActions)
@@ -261,7 +263,7 @@ namespace Plugin.LocalNotification.Platform.Droid
 
                     builder.AddAction(action);
                 }
-            }
+            }*/
 
             var notification = builder.Build();
             if (Build.VERSION.SdkInt < BuildVersionCodes.O &&
@@ -374,6 +376,8 @@ namespace Plugin.LocalNotification.Platform.Droid
 
         private string ToNativeCategory(NotificationCategoryTypes type)
         {
+
+       
             switch (type)
             {
                 case NotificationCategoryTypes.None:
@@ -390,6 +394,12 @@ namespace Plugin.LocalNotification.Platform.Droid
 
                 case NotificationCategoryTypes.System:
                     return NotificationCompat.CategorySystem;
+
+                case NotificationCategoryTypes.Error:
+                    return NotificationCompat.CategoryError;
+
+                case NotificationCategoryTypes.StopWatch:
+                    return NotificationCompat.CategoryStopwatch;
 
                 default:
                     return NotificationCompat.CategoryStatus;

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -1,10 +1,8 @@
 ﻿using Android.App;
 using Android.Content;
 using Android.Graphics;
-using Android.Graphics.Drawables;
 using Android.OS;
 using AndroidX.Core.App;
-using AndroidX.Core.Graphics.Drawable;
 using AndroidX.Work;
 using Java.Util.Concurrent;
 using System;
@@ -193,9 +191,9 @@ namespace Plugin.LocalNotification.Platform.Droid
                 }
             }
 
-            if (!string.IsNullOrEmpty(request.Category))
+            if (request.Category != NotificationCategoryTypes.None && Build.VERSION.SdkInt >= BuildVersionCodes.O)
             {
-                builder.SetCategory(request.Category);
+                builder.SetCategory(ToNativeCategory(request.Category));
             }
 
             if (Build.VERSION.SdkInt < BuildVersionCodes.O)
@@ -371,6 +369,30 @@ namespace Plugin.LocalNotification.Platform.Droid
             foreach(var action in notificationActions)
             {
                 NotificationActions.Add(action.Identifier, action);
+            }
+        }
+
+        private string ToNativeCategory(NotificationCategoryTypes type)
+        {
+            switch (type)
+            {
+                case NotificationCategoryTypes.None:
+                    return NotificationCompat.CategoryStatus;
+
+                case NotificationCategoryTypes.Alarm:
+                    return NotificationCompat.CategoryAlarm;
+
+                case NotificationCategoryTypes.Reminder:
+                    return NotificationCompat.CategoryReminder;
+
+                case NotificationCategoryTypes.Event:
+                    return NotificationCompat.CategoryEvent;
+
+                case NotificationCategoryTypes.System:
+                    return NotificationCompat.CategorySystem;
+
+                default:
+                    return NotificationCompat.CategoryStatus;
             }
         }
     }

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -29,7 +29,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                     var actionIdentifier = response.ActionIdentifier;
                     var userInfo = response.Notification.Request.Content.UserInfo;
 
-                    NotificationCenter.NotificationActions[actionIdentifier].Handler?.Invoke(localNotification.NotificationId, localNotification.ReturningData);
+                    NotificationCenter.Current.NotificationActions[actionIdentifier].Handler?.Invoke(localNotification.NotificationId, localNotification.ReturningData);
 
                     return;
                 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -21,14 +21,21 @@ namespace Plugin.LocalNotification.Platform.iOS
                     return;
                 }
 
+                var localNotification = GetRequest(response.Notification);
+
                 // Take action based on identifier
                 if (!response.IsDefaultAction)
                 {
+                    var actionIdentifier = response.ActionIdentifier;
+                    var userInfo = response.Notification.Request.Content.UserInfo;
+
+                    NotificationCenter.NotificationActions[actionIdentifier].Handler?.Invoke(localNotification.NotificationId, localNotification.ReturningData);
+
                     return;
                 }
 
-                var localNotification = GetRequest(response.Notification);
-
+                
+                
                 var args = new NotificationTappedEventArgs
                 {
                     Request = localNotification

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -1,6 +1,7 @@
 ﻿using Foundation;
 using Plugin.LocalNotification.Platform.iOS;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +12,8 @@ namespace Plugin.LocalNotification
 {
     public static partial class NotificationCenter
     {
+        public static Dictionary<string, NotificationAction> NotificationActions { get; set; } = new Dictionary<string, NotificationAction>();
+
         static NotificationCenter()
         {
             try
@@ -96,6 +99,24 @@ namespace Plugin.LocalNotification
                     uiApplication.ApplicationIconBadgeNumber = 0;
                 });
             });
+        }
+
+        /// <summary>
+        /// Register notification actions
+        /// </summary>
+        public static void RegisterActions(string categoryIdentifer, params NotificationAction[] actions)
+        {
+            foreach(var action in actions)
+            {
+                NotificationActions.Add(action.Identifier, action);
+            }
+
+            var UNNotificationActions = NotificationActions.Select(t => UNNotificationAction.FromIdentifier(t.Key, t.Value.Title, UNNotificationActionOptions.None));
+
+            var categories = UNNotificationCategory.FromIdentifier(categoryIdentifer, UNNotificationActions.ToArray(), Array.Empty<string>(), UNNotificationCategoryOptions.CustomDismissAction);
+
+            UNUserNotificationCenter.Current.SetNotificationCategories(new NSSet<UNNotificationCategory>(categories));
+
         }
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -1,7 +1,5 @@
-﻿using Foundation;
-using Plugin.LocalNotification.Platform.iOS;
+﻿using Plugin.LocalNotification.Platform.iOS;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,10 +10,6 @@ namespace Plugin.LocalNotification
 {
     public static partial class NotificationCenter
     {
-
-        // All identifiers must be unique
-        public static Dictionary<string, NotificationAction> NotificationActions { get; } = new Dictionary<string, NotificationAction>();
-
         static NotificationCenter()
         {
             try
@@ -101,58 +95,6 @@ namespace Plugin.LocalNotification
                     uiApplication.ApplicationIconBadgeNumber = 0;
                 });
             });
-        }
-
-        /// <summary>
-        /// Register notification categories and their corresponding actions
-        /// </summary>
-        public static void RegisterCategories(NotificationCategory[] notificationCategories)
-        {
-            var categories = new List<UNNotificationCategory>();
-
-            foreach (var category in notificationCategories)
-            {
-                var notificationCategory = RegisterActions(category);
-
-                categories.Add(notificationCategory);
-            }
-
-            UNUserNotificationCenter.Current.SetNotificationCategories(new NSSet<UNNotificationCategory>(categories.ToArray()));
-        }
-
-        private static UNNotificationCategory RegisterActions(NotificationCategory category)
-        {
-            foreach (var notificationAction in category.NotificationActions)
-            {
-                NotificationActions.Add(notificationAction.Identifier, notificationAction);
-            }
-
-            var notificationActions = category
-                .NotificationActions
-                .Select(t => UNNotificationAction.FromIdentifier(t.Identifier, t.Title, ToNativeActionType(t.ActionType)));
-
-            var notificationCategory = UNNotificationCategory
-                .FromIdentifier(category.Identifier, notificationActions.ToArray(), Array.Empty<string>(), UNNotificationCategoryOptions.CustomDismissAction);
-
-            return notificationCategory;
-        }
-
-        private static UNNotificationActionOptions ToNativeActionType(ActionTypes actionsType)
-        {
-            switch(actionsType)
-            {
-                case ActionTypes.Foreground:
-                    return UNNotificationActionOptions.Foreground;
-
-                case ActionTypes.Destructive:
-                    return UNNotificationActionOptions.Destructive;
-
-                case ActionTypes.AuthenticationRequired:
-                    return UNNotificationActionOptions.AuthenticationRequired;
-
-                default:
-                    return UNNotificationActionOptions.None;
-            }
         }
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -123,7 +123,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                     Badge = notificationRequest.BadgeNumber,
                     UserInfo = userInfoDictionary,
                     Sound = UNNotificationSound.Default,
-                    CategoryIdentifier = notificationRequest.Category,
+                    CategoryIdentifier = ToNativeCategory(notificationRequest.Category),
                 };
                 if (string.IsNullOrWhiteSpace(notificationRequest.Sound) == false)
                 {
@@ -236,7 +236,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                 .Select(t => UNNotificationAction.FromIdentifier(t.Identifier, t.Title, ToNativeActionType(t.ActionType)));
 
             var notificationCategory = UNNotificationCategory
-                .FromIdentifier(category.Identifier, notificationActions.ToArray(), Array.Empty<string>(), UNNotificationCategoryOptions.CustomDismissAction);
+                .FromIdentifier(ToNativeCategory(category.Type), notificationActions.ToArray(), Array.Empty<string>(), UNNotificationCategoryOptions.CustomDismissAction);
 
             return notificationCategory;
         }
@@ -256,6 +256,18 @@ namespace Plugin.LocalNotification.Platform.iOS
 
                 default:
                     return UNNotificationActionOptions.None;
+            }
+        }
+
+        private static string ToNativeCategory(NotificationCategoryTypes type)
+        {
+            switch (type)
+            {
+                case NotificationCategoryTypes.Alarm:
+                    return "ALARM";
+
+                default:
+                    return string.Empty;
             }
         }
     }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -1,7 +1,9 @@
 ﻿using Foundation;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using UIKit;
 using UserNotifications;
@@ -11,6 +13,10 @@ namespace Plugin.LocalNotification.Platform.iOS
     /// <inheritdoc />
     public class NotificationServiceImpl : INotificationService
     {
+
+        // All identifiers must be unique
+        public Dictionary<string, NotificationAction> NotificationActions { get; } = new Dictionary<string, NotificationAction>();
+
         /// <inheritdoc />
         public event NotificationTappedEventHandler NotificationTapped;
 
@@ -201,6 +207,56 @@ namespace Plugin.LocalNotification.Platform.iOS
                     Second = dateTime.Second
                 }
             };
+        }
+
+        /// <inheritdoc />
+        public void RegisterCategories(NotificationCategory[] notificationCategories)
+        {
+            var categories = new List<UNNotificationCategory>();
+
+            foreach (var category in notificationCategories)
+            {
+                var notificationCategory = RegisterActions(category);
+
+                categories.Add(notificationCategory);
+            }
+
+            UNUserNotificationCenter.Current.SetNotificationCategories(new NSSet<UNNotificationCategory>(categories.ToArray()));
+        }
+
+        private static UNNotificationCategory RegisterActions(NotificationCategory category)
+        {
+            foreach (var notificationAction in category.NotificationActions)
+            {
+                NotificationCenter.Current.NotificationActions.Add(notificationAction.Identifier, notificationAction);
+            }
+
+            var notificationActions = category
+                .NotificationActions
+                .Select(t => UNNotificationAction.FromIdentifier(t.Identifier, t.Title, ToNativeActionType(t.ActionType)));
+
+            var notificationCategory = UNNotificationCategory
+                .FromIdentifier(category.Identifier, notificationActions.ToArray(), Array.Empty<string>(), UNNotificationCategoryOptions.CustomDismissAction);
+
+            return notificationCategory;
+        }
+
+        private static UNNotificationActionOptions ToNativeActionType(ActionTypes actionsType)
+        {
+            switch (actionsType)
+            {
+                case ActionTypes.Foreground:
+                    return UNNotificationActionOptions.Foreground;
+
+                case ActionTypes.Destructive:
+                    return UNNotificationActionOptions.Destructive;
+
+                case ActionTypes.AuthenticationRequired:
+                    return UNNotificationActionOptions.AuthenticationRequired;
+
+                default:
+                    return UNNotificationActionOptions.None;
+            }
         }
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -77,6 +77,19 @@ namespace Plugin.LocalNotification.Platform.iOS
             }
         }
 
+        public void Pending()
+        {
+            
+
+            UNUserNotificationCenter.Current.GetPendingNotificationRequests(requests =>
+            {
+                foreach(var request in requests)
+                {
+                    var n = request.Content;
+                }
+            });
+        }
+
         /// <inheritdoc />
         public Task<bool> Show(Func<NotificationRequestBuilder, NotificationRequest> builder) => Show(builder.Invoke(new NotificationRequestBuilder()));
 
@@ -115,7 +128,8 @@ namespace Plugin.LocalNotification.Platform.iOS
                     Body = notificationRequest.Description,
                     Badge = notificationRequest.BadgeNumber,
                     UserInfo = userInfoDictionary,
-                    Sound = UNNotificationSound.Default
+                    Sound = UNNotificationSound.Default,
+                    CategoryIdentifier = notificationRequest.Category,
                 };
                 if (string.IsNullOrWhiteSpace(notificationRequest.Sound) == false)
                 {

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -77,19 +77,6 @@ namespace Plugin.LocalNotification.Platform.iOS
             }
         }
 
-        public void Pending()
-        {
-            
-
-            UNUserNotificationCenter.Current.GetPendingNotificationRequests(requests =>
-            {
-                foreach(var request in requests)
-                {
-                    var n = request.Content;
-                }
-            });
-        }
-
         /// <inheritdoc />
         public Task<bool> Show(Func<NotificationRequestBuilder, NotificationRequest> builder) => Show(builder.Invoke(new NotificationRequestBuilder()));
 
@@ -125,6 +112,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                 using var content = new UNMutableNotificationContent
                 {
                     Title = notificationRequest.Title,
+                    Subtitle = notificationRequest.Subtitle,
                     Body = notificationRequest.Description,
                     Badge = notificationRequest.BadgeNumber,
                     UserInfo = userInfoDictionary,

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -74,6 +74,9 @@
     <Compile Update="ActionTypes.cs">
       <SubType></SubType>
     </Compile>
+    <Compile Update="NotificationCategories.cs">
+      <SubType></SubType>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -65,6 +65,9 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="NotificationAction.cs">
+      <SubType></SubType>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -68,6 +68,12 @@
     <Compile Update="NotificationAction.cs">
       <SubType></SubType>
     </Compile>
+    <Compile Update="NotificationCategory.cs">
+      <SubType></SubType>
+    </Compile>
+    <Compile Update="ActionTypes.cs">
+      <SubType></SubType>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### What does this PR do?
Complete support for iOS notification actions.  Allowing you to register an action to be invoked after a notification action is tapped.

Subtitle support for notification and Android and iOS.

##### Why are we doing this? Any context or related work?

A request for this was opened under issues. I have iOS completed, Android is mostly done but still needs a service handler to complete. There is an abstraction layer that will allow a enum to power both iOS and Android action types.

https://github.com/thudugala/Plugin.LocalNotification/issues/111

