### PR TITLE
Add image support for iOS and some convenience helpers for iOS relate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,18 @@ The local notification plugin provides a way to show local notifications from Xa
 
 ## Platform Support
 
-| Feature              | Xamarin.iOS | Xamarin.Android |
-| -------------------- | ----------- | --------------- |
-| Required SDK         | >= 10       | >= API 19       |
-| Title                | [x]         | [x]             |
-| Description          | [x]         | [x]             |
-| Subtitle             | [x]         | [x]             |
-| Scheduled            | [x]         | [x]             |
-| Custom Sounds        | [x]         | [x]             |
-| Images               | [x]         | [ ]             |
-| Notification Actions | [x]         | [ ]             |
-|                      |             |                 |
+| Feature                 | Xamarin.iOS | Xamarin.Android |
+| ----------------------- | ----------- | --------------- |
+| Required SDK            | >= 10       | >= API 19       |
+| Title                   | ✅           | ✅               |
+| Description             | ✅           | ✅               |
+| Subtitle                | ✅           | ✅               |
+| Scheduled               | ✅           | ✅               |
+| Custom Sounds           | ✅           | ✅               |
+| Images                  | ✅           | ❌               |
+| Notification Actions    | ✅           | ❌               |
+| Pending Notifications   | ✅           | ❌               |
+| Delivered Notifications | ✅           | ❌               |
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,23 @@ The local notification plugin provides a way to show local notifications from Xa
 
 ## Platform Support
 
-|Platform|Supported|Version|Notes|
-| ------------------- | :-----------: | :------------------: | :------------------: |
-|Xamarin.iOS|Yes|iOS 10+| |
-|Xamarin.Android|Yes|API 19+|Project should [target Android framework 11.0+](https://docs.microsoft.com/en-us/xamarin/android/app-fundamentals/android-api-levels?tabs=vswin#framework)|
+| Feature              | Xamarin.iOS | Xamarin.Android |
+| -------------------- | ----------- | --------------- |
+| Required SDK         | >= 10       | >= API 19       |
+| Title                | [x]         | [x]             |
+| Description          | [x]         | [x]             |
+| Subtitle             | [x]         | [x]             |
+| Scheduled            | [x]         | [x]             |
+| Custom Sounds        | [x]         | [x]             |
+| Images               | [x]         | [ ]             |
+| Notification Actions | [x]         | [ ]             |
+|                      |             |                 |
+
+
+
+### Android Notes:
+
+Project should [target Android framework 11.0+](https://docs.microsoft.com/en-us/xamarin/android/app-fundamentals/android-api-levels?tabs=vswin#framework)
 
 # Usage
 

--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -61,6 +61,12 @@ namespace Plugin.LocalNotification
         /// </summary>
         public string Subtitle { get; set; } = string.Empty;
 
+
+        /// <summary>
+        /// Image for notification.  Use resource name for platforms.
+        /// </summary>
+        public string Image { get; set; } = string.Empty;
+
         /// <summary>
         /// Notification category for actions
         /// </summary>

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -1,5 +1,6 @@
 ﻿using Plugin.LocalNotification.Platform.iOS;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -94,6 +95,37 @@ namespace Plugin.LocalNotification
                 {
                     uiApplication.ApplicationIconBadgeNumber = 0;
                 });
+            });
+        }
+
+        /// <summary>
+        /// Get pending notifications
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<IEnumerable<iOSNotification>> PendingNotificationsAsync()
+        {
+            var pending = await UNUserNotificationCenter.Current.GetPendingNotificationRequestsAsync();
+
+            return pending.Select(t => new iOSNotification()
+            {
+                Id = t.Identifier,
+                Title = t.Content.Title
+
+            });
+        }
+
+        /// <summary>
+        /// Get notifications that are currently delivered
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<IEnumerable<iOSNotification>> DeliveredNotificationsAsync()
+        {
+            var delivered = await UNUserNotificationCenter.Current.GetDeliveredNotificationsAsync();
+
+            return delivered.Select(t => new iOSNotification()
+            {
+                Id = t.Request.Identifier,
+                Title = t.Request.Content.Title
             });
         }
     }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -128,9 +128,6 @@ namespace Plugin.LocalNotification
         {
             var pending = await UNUserNotificationCenter.Current.GetPendingNotificationRequestsAsync();
 
-            var notificationContent = pending.First().Content;
-
-
             return pending.Select(t => GetNotificationRequest(t));
         }
 
@@ -144,6 +141,5 @@ namespace Plugin.LocalNotification
 
             return delivered.Select(t => GetNotificationRequest(t.Request));
         }
-
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationCenter.cs
@@ -1,4 +1,5 @@
-﻿using Plugin.LocalNotification.Platform.iOS;
+﻿using Foundation;
+using Plugin.LocalNotification.Platform.iOS;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -98,35 +99,51 @@ namespace Plugin.LocalNotification
             });
         }
 
+
+        public static NotificationRequest GetNotificationRequest(UNNotificationRequest notification)
+        {
+            var notificationContent = notification?.Content;
+            if (notificationContent == null)
+            {
+                return null;
+            }
+            var dictionary = notificationContent.UserInfo;
+
+            if (!dictionary.ContainsKey(new NSString(NotificationCenter.ReturnRequest)))
+            {
+                return null;
+            }
+            var requestSerialize = dictionary[NotificationCenter.ReturnRequest].ToString();
+
+            var request = NotificationCenter.GetRequest(requestSerialize);
+
+            return request;
+        }
+
         /// <summary>
         /// Get pending notifications
         /// </summary>
         /// <returns></returns>
-        public static async Task<IEnumerable<iOSNotification>> PendingNotificationsAsync()
+        public static async Task<IEnumerable<NotificationRequest>> PendingNotificationsAsync()
         {
             var pending = await UNUserNotificationCenter.Current.GetPendingNotificationRequestsAsync();
 
-            return pending.Select(t => new iOSNotification()
-            {
-                Id = t.Identifier,
-                Title = t.Content.Title
+            var notificationContent = pending.First().Content;
 
-            });
+
+            return pending.Select(t => GetNotificationRequest(t));
         }
 
         /// <summary>
         /// Get notifications that are currently delivered
         /// </summary>
         /// <returns></returns>
-        public static async Task<IEnumerable<iOSNotification>> DeliveredNotificationsAsync()
+        public static async Task<IEnumerable<NotificationRequest>> DeliveredNotificationsAsync()
         {
             var delivered = await UNUserNotificationCenter.Current.GetDeliveredNotificationsAsync();
 
-            return delivered.Select(t => new iOSNotification()
-            {
-                Id = t.Request.Identifier,
-                Title = t.Request.Content.Title
-            });
+            return delivered.Select(t => GetNotificationRequest(t.Request));
         }
+
     }
 }

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using UIKit;
@@ -121,8 +122,28 @@ namespace Plugin.LocalNotification.Platform.iOS
                     Body = request.Description,
                     Badge = request.BadgeNumber,
                     UserInfo = userInfoDictionary,
-                    Sound = UNNotificationSound.Default
+                    Sound = UNNotificationSound.Default,
+                    
                 };
+
+                // Image Attachment
+                if (!string.IsNullOrWhiteSpace(request.Image))
+                {
+                    var e = Path.GetExtension(request.Image);
+                    var imageAttachment = NSBundle.MainBundle.GetUrlForResource(Path.GetFileNameWithoutExtension(request.Image), Path.GetExtension(request.Image));
+
+                    if(imageAttachment == null)
+                    {
+                        Debug.WriteLine("Failed to find attachment image. Make sure the image is marked as EmbeddedResource and the path is correct.");
+                        return false;
+                    }
+
+                    UNNotificationAttachmentOptions options = null;
+
+                    content.Attachments = new UNNotificationAttachment[] { UNNotificationAttachment.FromIdentifier("image", imageAttachment, options, out _) };
+                }
+
+
                 if (request.CategoryType != NotificationCategoryType.None)
                 {
                     content.CategoryIdentifier = ToNativeCategory(request.CategoryType);

--- a/Source/Plugin.LocalNotification/Platform/iOS/iOSNotification.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/iOSNotification.cs
@@ -1,0 +1,9 @@
+using System;
+namespace Plugin.LocalNotification.Platform.iOS
+{
+    public class iOSNotification
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/Source/Plugin.LocalNotification/Platform/iOS/iOSNotification.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/iOSNotification.cs
@@ -1,9 +1,0 @@
-using System;
-namespace Plugin.LocalNotification.Platform.iOS
-{
-    public class iOSNotification
-    {
-        public string Id { get; set; }
-        public string Title { get; set; }
-    }
-}


### PR DESCRIPTION
### What does this PR do?
This will add image attachments for iOS.

There are also some helper methods added to the iOS NotificationCenter class.  Android does not have this capability to it was isolated to NotificationCenter.

They allow you to see what notifications are schedules and also what has been delivered.

##### Why are we doing this? Any context or related work?
https://github.com/thudugala/Plugin.LocalNotification/issues/130