### PR TITLE
Reduced Xamarin.AndroidX.Core nuget dependency version to 1.3.2.3

### DIFF
--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.3" />
     <Compile Include="**/Platform/Droid/**/*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
### What does this PR do?
Fix a nuget dependency incompatibility with the latest Xamarin.Forms service release.

##### Why are we doing this? Any context or related work?
Plugin.LocalNotification currently depends on Xamarin.AndroidX.Core version >= 1.6.0 since the 8.0.2 release. In the latest Xamarin.Forms nuget release (v. 5.0.0.2083), the Xamarin team added an additional restriction to the Xamarin.AndroidX.Core nuget version which require a version in the following range: >= 1.3.2.3 && < 1.4.0.

This PR reduce the Xamarin.AndroidX.Core nuget dependency version to 1.3.2.3 to ensure compatibility with projects building on the latest Xamarin.Forms release.

I suggest to upgrade back the version of Xamarin.AndroidX.Core to 1.6.0 once the Xamarin team lift the restriction on a future Xamarin.Forms release.