### PR TITLE
Use select instead of cast to convert int array to string array

### DIFF
--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -53,7 +53,7 @@ namespace Plugin.LocalNotification.Platform.iOS
                     return false;
                 }
 
-                var itemList = notificationIdList.Cast<string>().ToArray();
+                var itemList = notificationIdList.Select((item) => item.ToString()).ToArray();
 
                 UNUserNotificationCenter.Current.RemovePendingNotificationRequests(itemList);
                 UNUserNotificationCenter.Current.RemoveDeliveredNotifications(itemList);


### PR DESCRIPTION
### What does this PR do?
Use select instead of cast to convert int array to string array in the notification service implementation on iOS.

##### Why are we doing this? Any context or related work?
When trying to cancel a notification on iOS a InvalidCastException is raised. This is because the Cast() function is unable to convert an array of ints to an array of strings.
