### PR TITLE
Added the DataOnly flag to scheduled notifications.

### DIFF
--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
@@ -49,7 +49,8 @@ namespace LocalNotification.Sample
                 },
             }));
 
-            NotificationCenter.Current.NotificationReceiving = OnNotificationReceiving;
+            NotificationCenter.Current.CustomizeNotification = OnCustomizeNotification;
+            NotificationCenter.Current.FilterNotification = OnFilterNotification;
             NotificationCenter.Current.NotificationReceived += ShowCustomAlertFromNotification;
             NotificationCenter.Current.NotificationActionTapped += Current_NotificationActionTapped;
 
@@ -61,7 +62,19 @@ namespace LocalNotification.Sample
             //ScheduleNotification("second", 20);
         }
 
-        private Task<NotificationRequest> OnNotificationReceiving(NotificationRequest request)
+        private Task<bool> OnFilterNotification(NotificationRequest request)
+        {
+            //return true to show the notification, false to suppress it
+            //this is only really useful for dealing with (recurring) scheduled notifications
+            if(_tapCount == 16)
+            {
+                return Task.FromResult(false);
+            }
+
+            return Task.FromResult(true);
+        }
+
+        private Task<NotificationRequest> OnCustomizeNotification(NotificationRequest request)
         {
             request.Title = $"{request.Title} Modified";
 

--- a/Source/Plugin.LocalNotification/INotificationService.cs
+++ b/Source/Plugin.LocalNotification/INotificationService.cs
@@ -94,8 +94,13 @@ namespace Plugin.LocalNotification
         Task<bool> Show(NotificationRequest request);
 
         /// <summary>
-        /// When Notification is about to be shown, this allow it to be modified. 
+        /// When Notification is about to be shown, this allows it to be modified. 
         /// </summary>
-        Func<NotificationRequest, Task<NotificationRequest>> NotificationReceiving { get; set; }
+        Func<NotificationRequest, Task<NotificationRequest>> CustomizeNotification { get; set; }
+
+        /// <summary>
+        /// When Notification is about to be shown, this allows it to be suppressed. 
+        /// </summary>
+        Func<NotificationRequest, Task<bool>> FilterNotification { get; set; }
     }
 }

--- a/Source/Plugin.LocalNotification/NotificationRequestSchedule.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequestSchedule.cs
@@ -28,6 +28,12 @@ namespace Plugin.LocalNotification
         public NotificationRepeat RepeatType { get; set; } = NotificationRepeat.No;
 
         /// <summary>
+        /// If set this notification will not attempt to create or display a notification, instead it will only invoke NotificationReceived.
+        /// Default is false
+        /// </summary>
+        public bool DataOnly { get; set; } = false;
+
+        /// <summary>
         /// In Android, do not Schedule or show notification if NotifyTime is earlier than DateTime.Now and this time delay.
         /// Default is 1 min
         /// </summary>

--- a/Source/Plugin.LocalNotification/Platform/Droid/ScheduledAlarmReceiver.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/ScheduledAlarmReceiver.cs
@@ -67,7 +67,21 @@ namespace Plugin.LocalNotification.Platform.Droid
                     return;
                 }
 
-                await notificationService.ShowNow(request);
+                if(!request.Schedule.DataOnly)
+                {
+                    //this call invokes OnNotificationReceived, but after the notification is shown, while iOS is _before_
+                    await notificationService.ShowNow(request);
+                }
+                else
+                {
+                    //this scheduled notification should not attempt to directly display a notification, instead it defers to the user
+                    var args = new NotificationEventArgs
+                    {
+                        Request = request
+                    };
+
+                    NotificationCenter.Current.OnNotificationReceived(args);
+                }
             }
             catch (Exception ex)
             {

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -47,10 +47,12 @@ namespace Plugin.LocalNotification.Platform.iOS
                                         Convert.ToInt32(response.Notification.Request.Content.Badge.ToString(), CultureInfo.CurrentCulture);
                         UIApplication.SharedApplication.ApplicationIconBadgeNumber = appBadges;
                     }
+
                     var args = new NotificationEventArgs
                     {
                         Request = request
                     };
+
                     notificationService.OnNotificationTapped(args);
                 });
             }

--- a/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/LocalNotificationDelegate.cs
@@ -81,7 +81,14 @@ namespace Plugin.LocalNotification.Platform.iOS
                     {
                         Request = localNotification
                     };
+
                     notificationService.OnNotificationReceived(args);
+
+                    if(localNotification.Schedule.DataOnly)
+                    {
+                        //do not attempt to display a notification to the user directly
+                        return;
+                    }
 
                     if (localNotification.iOS.HideForegroundAlert)
                     {

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceExtension.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceExtension.cs
@@ -36,34 +36,35 @@ namespace Plugin.LocalNotification.Platform.iOS
         #region Override Methods
 
         /// <inheritdoc />
-        public override async void DidReceiveNotificationRequest(UNNotificationRequest request, Action<UNNotificationContent> contentHandler)
+        public override async void DidReceiveNotificationRequest(UNNotificationRequest notificationRequest, Action<UNNotificationContent> contentHandler)
         {
             try
             {
                 ContentHandler = contentHandler;
 
-                BestAttemptContent = (UNMutableNotificationContent)request.Content.MutableCopy();
+                BestAttemptContent = (UNMutableNotificationContent)notificationRequest.Content.MutableCopy();
 
                 var notificationService = TryGetDefaultIOsNotificationService();
-                var notificationRequest = notificationService.GetRequest(request?.Content);
+                var request = notificationService.GetRequest(notificationRequest?.Content);
 
-                if (notificationService.NotificationReceiving != null)
+                if (notificationService.CustomizeNotification != null)
                 {
-                    var newLocalNotification = await notificationService.NotificationReceiving(notificationRequest);
-                    if (newLocalNotification != null)
+                    request = await notificationService.CustomizeNotification(request);
+                    if (request != null)
                     {
-                        var newtContent = await notificationService.GetNotificationContent(newLocalNotification);
+                        var newContent = await notificationService.GetNotificationContent(request);
 
-                        BestAttemptContent.Title = newtContent.Title;
-                        BestAttemptContent.Subtitle = newtContent.Subtitle;
-                        BestAttemptContent.Body = newtContent.Body;
-                        BestAttemptContent.Badge = newtContent.Badge;
-                        BestAttemptContent.UserInfo = newtContent.UserInfo;
-                        BestAttemptContent.Sound = newtContent.Sound;
-                        BestAttemptContent.Attachments = newtContent.Attachments;
-                        BestAttemptContent.CategoryIdentifier = newtContent.CategoryIdentifier;
+                        BestAttemptContent.Title = newContent.Title;
+                        BestAttemptContent.Subtitle = newContent.Subtitle;
+                        BestAttemptContent.Body = newContent.Body;
+                        BestAttemptContent.Badge = newContent.Badge;
+                        BestAttemptContent.UserInfo = newContent.UserInfo;
+                        BestAttemptContent.Sound = newContent.Sound;
+                        BestAttemptContent.Attachments = newContent.Attachments;
+                        BestAttemptContent.CategoryIdentifier = newContent.CategoryIdentifier;
                     }
                 }
+
                 ContentHandler(BestAttemptContent);
             }
             catch (Exception ex)


### PR DESCRIPTION
### What does this PR do?
~~As per #223 this adds a simple `DataOnly` flag to `NotificationRequestSchedule` to allow the user to manually determine how they would like to display the notification.~~

This now extends recent updates to add two separate callback functions:

- `CustomizeNotification` Used to customize notifications before they are shown to the user
- `FilterNotification` used to suppress notifications before they get queued to be shown (*without* cancelling the notification)

This allows for better customization of recurring scheduled notifications. The filtering needed to be split out into its own callback due to iOS requirements (TL;DR `NotificationServiceExtension` is not the place to suppress notifications according to Apple, and its actually just too late in the process anyway).

##### Why are we doing this? Any context or related work?
This is being done to allow recurring scheduled notifications to be customizable on a per-notification basis, in other words it exposes the scheduler to external code without being forced to display any notification (in essence allowing this library to also some-what function as a simple scheduling service).