### PR TITLE
FLAG_IMMUTABLE Bugfix for Android Version 31 and above.

### DIFF
--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -113,7 +113,7 @@ namespace Plugin.LocalNotification.Platform.Droid
                     Application.Context,
                     notificationId,
                     intent,
-                    ToPendingIntentFlags((AndroidPendingIntentFlags)PendingIntentFlags.CancelCurrent)
+                    SetImmutableIfNeeded(PendingIntentFlags.CancelCurrent)
                 );
 
                 MyAlarmManager?.Cancel(alarmIntent);
@@ -680,12 +680,23 @@ namespace Plugin.LocalNotification.Platform.Droid
         /// <returns></returns>
         protected virtual PendingIntentFlags ToPendingIntentFlags(AndroidPendingIntentFlags type)
         {
+            return SetImmutableIfNeeded((PendingIntentFlags)type);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        protected virtual PendingIntentFlags SetImmutableIfNeeded(PendingIntentFlags type)
+        {
+
             if ((int)Build.VERSION.SdkInt >= 31 &&
-                type.HasFlag(AndroidPendingIntentFlags.Immutable) == false)
+                type.HasFlag(PendingIntentFlags.Immutable) == false)
             {
-                type |= AndroidPendingIntentFlags.Immutable;
+                type |= PendingIntentFlags.Immutable;
             }
-            return (PendingIntentFlags)type;
+            return type;
         }
 
         /// <inheritdoc />

--- a/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/NotificationServiceImpl.cs
@@ -113,7 +113,7 @@ namespace Plugin.LocalNotification.Platform.Droid
                     Application.Context,
                     notificationId,
                     intent,
-                    PendingIntentFlags.CancelCurrent
+                    ToPendingIntentFlags((AndroidPendingIntentFlags)PendingIntentFlags.CancelCurrent)
                 );
 
                 MyAlarmManager?.Cancel(alarmIntent);


### PR DESCRIPTION
### What does this PR do?
Fixes the FLAG_IMMUTABLE error thrown by Android Version 31 and above, specifically when calling the Cancel method of NotificationServiceImpl.cs

##### Why are we doing this? Any context or related work?
My application started crashing on its call to Notification Factory's DeleteGroup method. This fixes that error.
