### PR TITLE
Fixes thudugala/Plugin.LocalNotification#251 Add NotifyTime check to BootReceiver

### DIFF
--- a/Source/Plugin.LocalNotification/Platform/Droid/BootReceiver.cs
+++ b/Source/Plugin.LocalNotification/Platform/Droid/BootReceiver.cs
@@ -47,7 +47,10 @@ namespace Plugin.LocalNotification.Platform.Droid
                 var notificationService = TryGetDefaultDroidNotificationService();
                 foreach (var request in activeForReScheduleRequestList)
                 {
-                    request.Schedule.NotifyTime = request.GetNextNotifyTime();
+                    if (request.Schedule.NotifyTime < DateTime.Now)
+                    {
+                        request.Schedule.NotifyTime = request.GetNextNotifyTime();
+                    }
 
                     // re schedule again.
                     NotificationCenter.Log($"ReScheduled Notification Request {request.NotificationId}");


### PR DESCRIPTION

### What does this PR do?
Adds a check in BootReceiver to see if the request NotifyTime has already passed before calling GetNextNotifyTime() to increment the repeating notification by the specified time.

##### Why are we doing this? Any context or related work?
Multiple reboots on an Android device before the NotifyTime is reached will push the NotifyTime further and further into the future.
As described in #251 