### PR TITLE
Various updates

### DIFF
--- a/Sample/Direct/LocalNotification.Sample.Android/LocalNotification.Sample.Android.csproj
+++ b/Sample/Direct/LocalNotification.Sample.Android/LocalNotification.Sample.Android.csproj
@@ -15,11 +15,9 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <UseShortFileNames>True</UseShortFileNames>
-    <IntermediateOutputPath>C:\temp\LocalNotification</IntermediateOutputPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -66,8 +64,6 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidPackageFormat>aab</AndroidPackageFormat>
     <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
-    <AndroidLinkSkip>
-    </AndroidLinkSkip>
     <AndroidDexTool>d8</AndroidDexTool>
   </PropertyGroup>
   <ItemGroup>
@@ -121,7 +117,7 @@
       <Name>Plugin.LocalNotification</Name>
     </ProjectReference>
     <ProjectReference Include="..\LocalNotification.Sample\LocalNotification.Sample.csproj">
-      <Project>{DFF878F7-002D-481C-9311-C49B8D150775}</Project>
+      <Project>{1CB8A3CC-A5FB-4D8D-9686-1374FAC0ABC3}</Project>
       <Name>LocalNotification.Sample</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Sample/Direct/LocalNotification.Sample/App.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/App.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Plugin.LocalNotification.EventArgs;
 using Xamarin.Forms;
+using System.Threading.Tasks;
 
 namespace LocalNotification.Sample
 {
@@ -21,7 +22,17 @@ namespace LocalNotification.Sample
 
             NotificationCenter.NotificationLog += NotificationCenter_NotificationLog;
             NotificationCenter.Current.NotificationTapped += LoadPageFromNotification;
+            NotificationCenter.Current.NotificationReceiving = (request) =>
+            {
+                return Task.FromResult(new NotificationEventReceivingArgs
+                {
+                    Handled = NotificationHandled,
+                    Request = request //  This is read only on iOS, you can not modify a local notification
+                }); 
+            };
         }
+
+        public static bool NotificationHandled { get; set; }
 
         private void NotificationCenter_NotificationLog(NotificationLogArgs e)
         {

--- a/Sample/Direct/LocalNotification.Sample/LocalNotification.Sample.csproj
+++ b/Sample/Direct/LocalNotification.Sample/LocalNotification.Sample.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <None Remove="icon.png" />
+    <None Remove="Xamarin.CommunityToolkit" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
+    <PackageReference Include="Xamarin.CommunityToolkit" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml
@@ -5,8 +5,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:local="clr-namespace:LocalNotification.Sample"
+    x:DataType="local:MainViewModel"
     Title="Main"
     ios:Page.UseSafeArea="true">
+
+    <ContentPage.BindingContext>
+        <local:MainViewModel />
+    </ContentPage.BindingContext>
 
     <StackLayout>
         <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
@@ -29,6 +34,10 @@
         <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
             <Label Text="Use Custom Sound" />
             <Switch x:Name="CustomSoundSwitch" IsToggled="false" />
+        </StackLayout>
+        <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
+            <Label Text="Handle Notification Manually (Data only)" />
+            <Switch x:Name="HandleNotification" IsToggled="{Binding NotificationHandled}"  />
         </StackLayout>
         <Label HorizontalOptions="Center" Text="In Android &gt;= 26, Use NotificationChannel to set Sound" />
 

--- a/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainPage.xaml.cs
@@ -129,14 +129,18 @@ namespace LocalNotification.Sample
                     },
                     IsProgressBarIndeterminate = false,
                     ProgressBarMax = 20,
-                    ProgressBarProgress = _tapCount
+                    ProgressBarProgress = _tapCount,
+                    Group = "test"
                     //AutoCancel = false,
                     //Ongoing = true
                 },
                 iOS =
                 {
                     HideForegroundAlert = CustomAlert.IsToggled,
-                    PlayForegroundSound = ForegroundSound.IsToggled
+                    PlayForegroundSound = ForegroundSound.IsToggled,
+                    ThreadIdentifier = "test",
+                    RelevanceScore = 0.5,
+                    Priority = iOSNotificationPriority.Active
                 }
             };
 

--- a/Sample/Direct/LocalNotification.Sample/MainViewModel.cs
+++ b/Sample/Direct/LocalNotification.Sample/MainViewModel.cs
@@ -1,0 +1,13 @@
+using System;
+using Xamarin.CommunityToolkit.ObjectModel;
+
+namespace LocalNotification.Sample
+{
+    public class MainViewModel : ObservableObject
+    {
+        public bool NotificationHandled
+        {
+            get => App.NotificationHandled; set => App.NotificationHandled = value;
+        }
+    }
+}

--- a/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/NotificationServiceImpl.cs
@@ -2,7 +2,6 @@
 using Plugin.LocalNotification.iOSOption;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -204,7 +203,15 @@ namespace Plugin.LocalNotification.Platform.iOS
                 Badge = request.BadgeNumber,
                 UserInfo = userInfoDictionary,
                 Sound = UNNotificationSound.Default,
+                ThreadIdentifier = request.iOS.ThreadIdentifier
             };
+
+            if(UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
+            {
+                content.InterruptionLevel = (UNNotificationInterruptionLevel)request.iOS.Priority;
+                content.RelevanceScore = request.iOS.RelevanceScore;
+            }
+
             // Image Attachment
             if (request.Image != null)
             {
@@ -264,13 +271,11 @@ namespace Plugin.LocalNotification.Platform.iOS
             {
                 using (var stream = new MemoryStream(notificationImage.Binary))
                 {
-                    var image = Image.FromStream(stream);
-                    var imageExtension = image.RawFormat.ToString();
 
                     var cache = NSSearchPath.GetDirectories(NSSearchPathDirectory.CachesDirectory,
                         NSSearchPathDomain.User);
                     var cachesFolder = cache[0];
-                    var cacheFile = $"{cachesFolder}{NSProcessInfo.ProcessInfo.GloballyUniqueString}.{imageExtension}";
+                    var cacheFile = $"{cachesFolder}{NSProcessInfo.ProcessInfo.GloballyUniqueString}";
 
                     if (File.Exists(cacheFile))
                     {

--- a/Source/Plugin.LocalNotification/Platform/iOS/UserNotificationCenterDelegate.cs
+++ b/Source/Plugin.LocalNotification/Platform/iOS/UserNotificationCenterDelegate.cs
@@ -77,7 +77,7 @@ namespace Plugin.LocalNotification.Platform.iOS
         }
 
         /// <inheritdoc />
-        public override void WillPresentNotification(UNUserNotificationCenter center, UNNotification notification,
+        public override async void WillPresentNotification(UNUserNotificationCenter center, UNNotification notification,
             Action<UNNotificationPresentationOptions> completionHandler)
         {
             try
@@ -109,6 +109,18 @@ namespace Plugin.LocalNotification.Platform.iOS
                 }
 
                 var requestHandled = false;
+
+                if(NotificationCenter.Current.NotificationReceiving != null)
+                {
+                    var result = await NotificationCenter.Current.NotificationReceiving.Invoke(notificationRequest);
+
+                    if (result.Handled)
+                    {
+                        requestHandled = true;
+                        presentationOptions = UNNotificationPresentationOptions.None;
+                    }
+                }
+
                 var dictionary = notification?.Request.Content.UserInfo;
                 if (dictionary != null)
                 {

--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -63,6 +63,9 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="iOSOption\iOSNotificationPriority.cs">
+      <SubType></SubType>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Plugin.LocalNotification/iOSOption/iOSNotificationPriority.cs
+++ b/Source/Plugin.LocalNotification/iOSOption/iOSNotificationPriority.cs
@@ -1,0 +1,26 @@
+using System;
+namespace Plugin.LocalNotification.iOSOption
+{
+    public enum iOSNotificationPriority
+    {
+        /// <summary>
+        /// The system adds the notification to the notification list without lighting up the screen or playing a sound.
+        /// </summary>
+        Passive = 0,
+
+        /// <summary>
+        /// The system presents the notification immediately, lights up the screen, and can play a sound. (default)
+        /// </summary>
+        Active = 1,
+
+        /// <summary>
+        /// The system presents the notification immediately, lights up the screen, and can play a sound, but won’t break through system notification controls.
+        /// </summary>
+        TimeSensitive = 2,
+
+        /// <summary>
+        /// The system presents the notification immediately, lights up the screen, and bypasses the mute switch to play a sound.
+        /// </summary>
+        Critical = 3
+    }
+}

--- a/Source/Plugin.LocalNotification/iOSOption/iOSOptions.cs
+++ b/Source/Plugin.LocalNotification/iOSOption/iOSOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Plugin.LocalNotification.iOSOption
+﻿using System;
+
+namespace Plugin.LocalNotification.iOSOption
 {
     /// <summary>
     /// NotificationRequest for iOS
@@ -16,5 +18,21 @@
         /// Default is false
         /// </summary>
         public bool PlayForegroundSound { get; set; }
+
+        /// <summary>
+        /// Setting this will enable iOS to deliver acitve, passive. time-sensentive (high priority) and critical require entitlements
+        /// Default is active
+        /// </summary>
+        public iOSNotificationPriority Priority { get; set; } = iOSNotificationPriority.Active;
+
+        /// <summary>
+        /// The system uses the relevanceScore, a value between 0 and 1, to sort the notifications from your app. The highest score gets featured in the notification summary.
+        /// </summary>
+        public double RelevanceScore { get; set; }
+
+        /// <summary>
+        /// An identifier that you use to group related notifications together.
+        /// </summary>
+        public string ThreadIdentifier { get; set; }
     }
 }


### PR DESCRIPTION
### What does this PR do?

1. Added iOS 15 options for time sensitive notifications and relevance score (sorting notifications)
2. Fixed issue with references to System.Drawing causing crash on iOS when using images from byte[]
3. Added thread identifier to allow you to group notifications on iOS - perhaps this can be called from a WithGroup(string) method on the builder
4. Added “data only” notifications for iOS. A use case for this allows you to mark a notification as handled so it will not present. This would be useful if you scheduled a reminder with a reminder 20 minutes after that reminder if no action was taken.  But you don't want to show that notification if action was taken.

For more details on iOS 15 notification changes, see https://onesignal.com/blog/ios-notification-changes-updates-from-apples-wwdc-21/

##### Why are we doing this? Any context or related work?

This addresses:

https://github.com/thudugala/Plugin.LocalNotification/issues/223
https://github.com/thudugala/Plugin.LocalNotification/pull/224


