### PR TITLE
Fix building for iOS with maui

### DIFF
--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -55,23 +55,14 @@
     <None Include="**/Platform/**/*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid')) Or $(TargetFramework.Contains('-android'))">
     <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.3" />
     <Compile Include="**/Platform/Droid/**/*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS')) Or $(TargetFramework.Contains('-ios'))">
     <Compile Include="**/Platform/iOS/**/*.cs" />
   </ItemGroup>
-
-	<ItemGroup Condition="$(TargetFramework.StartsWith('-android'))">
-		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.3" />
-		<Compile Include="**/Platform/Droid/**/*.cs" />
-	</ItemGroup>
-
-	<ItemGroup Condition="$(TargetFramework.StartsWith('-ios'))">
-		<Compile Include="**/Platform/iOS/**/*.cs" />
-	</ItemGroup>
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
### What does this PR do?
iOS build was failing because StartsWith framework `-ios` will forever be impossible, also tidied up the csproj a little

##### Why are we doing this? Any context or related work?
#270