### PR TITLE
Removed Android Version check in IOS Implementation

### DIFF
--- a/Source/Plugin.LocalNotification/Platforms/iOS/NotificationServiceImpl.cs
+++ b/Source/Plugin.LocalNotification/Platforms/iOS/NotificationServiceImpl.cs
@@ -56,7 +56,7 @@ namespace Plugin.LocalNotification.Platforms
                 return false;
             }
 #elif IOS
-            if (!OperatingSystem.IsAndroidVersionAtLeast(10))
+            if (!OperatingSystem.IsIOSVersionAtLeast(10))
             {
                 return false;
             }


### PR DESCRIPTION
### What does this PR do?
Android was referenced to check for at least version 10 of the Operating System on the Notification Service implementation for IOS. This reference was updated to match the rest of the IOS Implementation in the file.