### PR TITLE
Correct documentation typo

### DIFF
--- a/Source/Plugin.LocalNotification/NotificationRequest.cs
+++ b/Source/Plugin.LocalNotification/NotificationRequest.cs
@@ -58,7 +58,7 @@ namespace Plugin.LocalNotification
         public string ReturningData { get; set; } = string.Empty;
 
         /// <summary>
-        /// Schedule notification (canot be mixed with geofence)
+        /// Schedule notification (cannot be mixed with geofence)
         /// </summary>
         public NotificationRequestSchedule Schedule { get; set; } = new();
 


### PR DESCRIPTION
### What does this PR do?
Correct a typo in a property's documentation.

##### Why are we doing this? Any context or related work?
Started using the library, noticed the typo, and would like to fix it for you.