### PR TITLE
Added debug error exception

### DIFF
--- a/Source/Plugin.LocalNotification/Platforms/Android/LocalNotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platforms/Android/LocalNotificationCenter.cs
@@ -1,5 +1,6 @@
 ﻿using Android.App;
 using Android.Content;
+using Android.Content.Res;
 using Android.Media;
 using Microsoft.Extensions.Logging;
 using Plugin.LocalNotification.AndroidOption;
@@ -151,11 +152,18 @@ namespace Plugin.LocalNotification
                 return Android.Net.Uri.Parse(soundFileName);
             }
 
-            soundFileName = Path.GetFileNameWithoutExtension(soundFileName);
-            soundFileName =
-                $"{ContentResolver.SchemeAndroidResource}://{Application.Context.PackageName}/raw/{soundFileName}";
+            var soundNameWithoutExtension = Path.GetFileNameWithoutExtension(soundFileName);
+            var soundFilePath = $"{ContentResolver.SchemeAndroidResource}://{Application.Context.PackageName}/raw/{soundNameWithoutExtension}";
+            var soundFileUri = Android.Net.Uri.Parse(soundFilePath);
 
-            return Android.Net.Uri.Parse(soundFileName);
+#if DEBUG
+            if (soundFileUri is null || !soundFileUri.IsValidResource(Application.Context))
+            {
+                throw new ArgumentException($"Invalid sound file: {soundFileName}. Your sound has to be AndroidResource stored in Platforms/Android/Resources/raw");
+            }
+#endif
+
+            return soundFileUri;
         }
 
         /// <summary>

--- a/Source/Plugin.LocalNotification/Platforms/Android/PlatformExtensions.cs
+++ b/Source/Plugin.LocalNotification/Platforms/Android/PlatformExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Android.App;
+using Android.Content;
 using AndroidX.Core.App;
 using Plugin.LocalNotification.AndroidOption;
 using Application = Android.App.Application;
@@ -145,6 +146,25 @@ namespace Plugin.LocalNotification.Platforms
             }
 
             return type;
+        }
+
+        internal static bool IsValidResource(this Android.Net.Uri uri, Context context)
+        {
+            var contentResolver = context.ContentResolver;
+            if (contentResolver is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                contentResolver.OpenInputStream(uri)?.Close();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
If developer doesnt store sound as Android resource correctly in `raw` folder an exception is triggered

##### Why are we doing this? Any context or related work?
I missed a part in docs where was explained where should be the sound stored. This way it becomes more obvious.
