### PR TITLE
Updated GooglePlayServices nuget

### DIFF
--- a/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
+++ b/Source/Plugin.LocalNotification/Plugin.LocalNotification.csproj
@@ -73,7 +73,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-    <PackageReference Include="Xamarin.GooglePlayServices.Location" Version="121.0.1.2" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Location" Version="121.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">


### PR DESCRIPTION
### What does this PR do?
Just updating package: `Xamarin.GooglePlayServices.Location` to the latest version

##### Why are we doing this? Any context or related work?
Google play keeps reporting problem:
`Your use of exact alarms is causing your app to crash for some Android users`

and also:
`Library versions that have known defects. Your app has dependencies on these versions. If not updated, these defective library versions may cause your app to crash.`

the library with defect is `com.google.android.gms` and this package contains updated version.

Could potentially solve: https://github.com/thudugala/Plugin.LocalNotification/issues/465
