### PR TITLE
Increase Source unit test coverage to 100%

### DIFF
--- a/UnitTests/LocalNotification.UnitTests/CollectionDefinitions.cs
+++ b/UnitTests/LocalNotification.UnitTests/CollectionDefinitions.cs
@@ -1,3 +1,5 @@
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace Plugin.LocalNotification.UnitTests;
 
 /// <summary>

--- a/UnitTests/LocalNotification.UnitTests/LocalNotification.UnitTests.csproj
+++ b/UnitTests/LocalNotification.UnitTests/LocalNotification.UnitTests.csproj
@@ -21,6 +21,7 @@
 		<PackageReference Include="FluentAssertions" Version="8.8.0" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
 		<PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -41,6 +42,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\Plugin.LocalNotification.Core\Plugin.LocalNotification.Core.csproj" />
 		<ProjectReference Include="..\..\Source\Plugin.LocalNotification\Plugin.LocalNotification.csproj" />
+		<ProjectReference Include="..\..\Source\Plugin.LocalNotification.Geofence\Plugin.LocalNotification.Geofence.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/UnitTests/LocalNotification.UnitTests/Tests/CoverageTests.cs
+++ b/UnitTests/LocalNotification.UnitTests/Tests/CoverageTests.cs
@@ -1,11 +1,14 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Plugin.LocalNotification.AndroidOption;
 using Plugin.LocalNotification.Core;
 using Plugin.LocalNotification.Core.Models;
 using Plugin.LocalNotification.Core.Models.AndroidOption;
 using Plugin.LocalNotification.Core.Models.AppleOption;
 using Plugin.LocalNotification.EventArgs;
+using Plugin.LocalNotification.Geofence;
 using Plugin.LocalNotification.Platforms;
+using Plugin.LocalNotification.Properties;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -853,5 +856,94 @@ public class CoverageTests : IDisposable
         // INotificationService interface declares GetActiveNotifications
         var ifaceMethods = typeof(INotificationService).GetMethods();
         ifaceMethods.Should().Contain(m => m.Name == nameof(INotificationService.GetActiveNotifications));
+    }
+
+    [Fact]
+    public void Phase13_ChannelDefaultsAndResources_ShouldCoverRemainingSourceLines()
+    {
+        var channel = new AndroidNotificationChannelRequest();
+        channel.LockScreenVisibility.Should().Be(AndroidVisibilityType.Private);
+        channel.CanBypassDnd.Should().BeFalse();
+
+        _ = new Resources();
+        Resources.ResourceManager.Should().NotBeNull();
+        Resources.Culture = null;
+        Resources.Culture.Should().BeNull();
+        Resources.AndroidAlarmServiceNotFound.Should().NotBeNullOrEmpty();
+        Resources.AndroidNotificationServiceNotFound.Should().NotBeNullOrEmpty();
+        Resources.GeofencePackageMissing.Should().NotBeNullOrEmpty();
+        Resources.PluginNotFound.Should().NotBeNullOrEmpty();
+        Resources.PluginSerializerNotFound.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Phase14_MauiAndInitializeService_ShouldCoverInitializationAndExtensionReturnPath()
+    {
+        var useMethod = typeof(LocalNotificationExtensions).GetMethod(nameof(LocalNotificationExtensions.UseLocalNotification), BindingFlags.Public | BindingFlags.Static);
+        useMethod.Should().NotBeNull();
+        var returnedBuilder = useMethod!.Invoke(null, [null, null]);
+        returnedBuilder.Should().BeNull();
+
+        var logger = NullLogger<LocalNotificationCenter>.Instance;
+        var notificationService = new Mock<INotificationService>();
+        LocalNotificationCenter.SetNotificationService(notificationService.Object);
+
+        var customSerializer = new Mock<INotificationSerializer>().Object;
+        var localBuilder = new LocalNotificationBuilder();
+        var category = new NotificationCategory(NotificationCategoryType.Status);
+        localBuilder.SetSerializer(customSerializer);
+        localBuilder.AddCategory(category);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(s => s.GetService(typeof(ILogger<LocalNotificationCenter>))).Returns(logger);
+        serviceProvider.Setup(s => s.GetService(typeof(LocalNotificationBuilder))).Returns(localBuilder);
+
+        var initializer = new LocalNotificationInitializeService();
+        initializer.Initialize(serviceProvider.Object);
+
+        LocalNotificationLogger.Logger.Should().NotBeNull();
+        LocalNotificationCenter.Serializer.Should().BeSameAs(customSerializer);
+        notificationService.Verify(s => s.RegisterCategoryList(It.Is<HashSet<NotificationCategory>>(set => set.Contains(category))), Times.Once);
+    }
+
+    [Fact]
+    public void Phase15_TrimImageBinary_ShouldCoverExceptionPath()
+    {
+        const int notificationId = 777;
+        var imageDir = Path.Combine(Path.GetTempPath(), "Plugin.LocalNotification", "images");
+        var imagePath = Path.Combine(imageDir, $"img_{notificationId}.bin");
+        Directory.CreateDirectory(imageDir);
+        File.WriteAllBytes(imagePath, [1, 2, 3]);
+        File.SetAttributes(imagePath, FileAttributes.ReadOnly);
+
+        var request = new NotificationRequest
+        {
+            NotificationId = notificationId,
+            Image = new NotificationImage { Binary = new byte[100_001] }
+        };
+
+        try
+        {
+            var serialized = LocalNotificationCenter.GetRequestSerialize(request);
+            serialized.Should().NotBeNullOrWhiteSpace();
+            request.Image.Binary.Should().BeEmpty();
+        }
+        finally
+        {
+            if (File.Exists(imagePath))
+            {
+                File.SetAttributes(imagePath, FileAttributes.Normal);
+                File.Delete(imagePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void Phase16_GeofenceExtension_ShouldCoverReturnPath()
+    {
+        var useMethod = typeof(GeofenceExtensions).GetMethod(nameof(GeofenceExtensions.UseLocalNotificationGeofence), BindingFlags.Public | BindingFlags.Static);
+        useMethod.Should().NotBeNull();
+        var returnedBuilder = useMethod!.Invoke(null, [null]);
+        returnedBuilder.Should().BeNull();
     }
 }


### PR DESCRIPTION
### What does this PR do?

Raises unit test coverage for code under `Source/` to 100% line coverage from `UnitTests/LocalNotification.UnitTests` by adding targeted tests for previously uncovered paths and wiring the test project to include Geofence source coverage.

- Adds focused coverage tests for remaining uncovered Source lines (resource accessors, initialization flow, extension return paths, and `TrimImageBinary` exception path).
- Adds `Plugin.LocalNotification.Geofence` as a test project reference so Source Geofence code is included in coverage.
- Adds `Microsoft.Maui.Controls` to the test project so MAUI-linked Source types used by tests can load.
- Disables unit test parallelization at assembly level to avoid static-state interference in coverage tests.

##### Why are we doing this? Any context or related work?

The goal was to ensure Source folder unit test coverage is fully complete and stable. Existing tests passed but left a few Source paths uncovered and were susceptible to shared static state collisions when run in parallel. These updates close the remaining gaps and make coverage runs deterministic.