### PR TITLE
Fix: Handle null notification array in ResetApplicationIconBadgeNumber

### DIFF
--- a/Source/Plugin.LocalNotification/Platforms/MacCatalyst/LocalNotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platforms/MacCatalyst/LocalNotificationCenter.cs
@@ -61,10 +61,14 @@ public partial class LocalNotificationCenter
             var completionSource = new TaskCompletionSource<bool>();
             UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationArray) =>
             {
-                notificationList.AddRange(notificationArray);
+                if (notificationArray != null)
+                {
+                    notificationList.AddRange(notificationArray);
+                }
                 completionSource.SetResult(true);
             });
             completionSource.Task.Wait();
+                
             if (notificationList.Count != 0)
             {
                 return;

--- a/Source/Plugin.LocalNotification/Platforms/iOS/LocalNotificationCenter.cs
+++ b/Source/Plugin.LocalNotification/Platforms/iOS/LocalNotificationCenter.cs
@@ -61,10 +61,14 @@ public partial class LocalNotificationCenter
             var completionSource = new TaskCompletionSource<bool>();
             UNUserNotificationCenter.Current.GetDeliveredNotifications((notificationArray) =>
             {
-                notificationList.AddRange(notificationArray);
+                if (notificationArray != null)
+                {
+                    notificationList.AddRange(notificationArray);
+                }
                 completionSource.SetResult(true);
             });
             completionSource.Task.Wait();
+                
             if (notificationList.Count != 0)
             {
                 return;


### PR DESCRIPTION
### What does this PR do?

Improves null handling in the `ResetApplicationIconBadgeNumber()` method by adding an early return in the callback when `notificationArray` is null. This prevents an `ArgumentNullException` when iOS's `GetDeliveredNotifications()` callback returns a null array instead of an empty array.

##### Why are we doing this? Any context or related work?

The synchronous version of `ResetApplicationIconBadgeNumber()` was throwing `ArgumentNullException` because the iOS SDK's `GetDeliveredNotifications()` callback can pass a null notification array, but the code unconditionally called `AddRange(notificationArray)` without null checking. The async version (`ResetApplicationIconBadgeNumberAsync()`) doesn't have this issue because `GetDeliveredNotificationsAsync()` returns an empty array instead of null.

**Changes made:**
- Added null check with early return in the callback before `AddRange()` in `Platforms/iOS/LocalNotificationCenter.cs`
- Added null check with early return in the callback before `AddRange()` in `Platforms/MacCatalyst/LocalNotificationCenter.cs`

This approach treats a null notification array gracefully and continues execution as if there are no notifications, which is the correct behavior.

Fixes: #545